### PR TITLE
Fix rpc declare and deploy after devnet update

### DIFF
--- a/lib/src/main/kotlin/starknet/extensions/json.kt
+++ b/lib/src/main/kotlin/starknet/extensions/json.kt
@@ -5,3 +5,5 @@ import starknet.data.types.Felt
 
 fun JsonObjectBuilder.put(key: String, value: Felt?): JsonElement? =
     put(key, JsonPrimitive(value?.hexString() ?: Felt.ZERO.hexString()))
+
+fun JsonArrayBuilder.add(value: Felt): Boolean = add(JsonPrimitive(value.hexString()))

--- a/lib/src/main/kotlin/starknet/provider/rpc/JsonRpcProvider.kt
+++ b/lib/src/main/kotlin/starknet/provider/rpc/JsonRpcProvider.kt
@@ -10,6 +10,8 @@ import starknet.provider.Provider
 import starknet.provider.Request
 import starknet.service.http.HttpRequest
 import starknet.service.http.HttpService
+import starknet.extensions.add
+import starknet.extensions.put
 
 /**
  * A provider for interacting with StarkNet JSON-RPC
@@ -188,12 +190,9 @@ class JsonRpcProvider(
         val params = buildJsonObject {
             put("contract_definition", payload.contractDefinition.toRpcJson())
             putJsonArray("constructor_calldata") {
-//                FIXME(restore this once devnet accepts our PR
-//                payload.constructorCalldata.forEach { addFeltAsHex(it) }
-                payload.constructorCalldata.forEach { add(it.value.intValueExact()) }
+                payload.constructorCalldata.forEach { add(it) }
             }
-//            putFeltAsHex("contract_address_salt", payload.salt)
-            put("contract_address_salt", payload.salt.value.intValueExact())
+            put("contract_address_salt", payload.salt)
         }
 
         return buildRequest(JsonRpcMethod.DEPLOY, params, DeployResponse.serializer())
@@ -202,9 +201,7 @@ class JsonRpcProvider(
     override fun declareContract(payload: DeclareTransactionPayload): Request<DeclareResponse> {
         val params = buildJsonObject {
             put("contract_class", payload.contractDefinition.toRpcJson())
-//            FIXME(restore this once devnet accepts our PR
-//            putFeltAsHex("version", payload.version)
-            put("version", 0)
+            put("version", payload.version)
         }
 
         return buildRequest(JsonRpcMethod.DECLARE, params, DeclareResponse.serializer())

--- a/lib/src/main/kotlin/starknet/provider/rpc/JsonRpcProvider.kt
+++ b/lib/src/main/kotlin/starknet/provider/rpc/JsonRpcProvider.kt
@@ -6,12 +6,12 @@ import starknet.data.responses.Transaction
 import starknet.data.responses.TransactionReceipt
 import starknet.data.responses.serializers.JsonRpcTransactionPolymorphicSerializer
 import starknet.data.types.*
+import starknet.extensions.add
+import starknet.extensions.put
 import starknet.provider.Provider
 import starknet.provider.Request
 import starknet.service.http.HttpRequest
 import starknet.service.http.HttpService
-import starknet.extensions.add
-import starknet.extensions.put
 
 /**
  * A provider for interacting with StarkNet JSON-RPC


### PR DESCRIPTION
Starknet-devnet merged our fix to the RPC endpoint so temporary fixes introduced in starknet-jvm need to be reverted.