### PR TITLE
Restore some of the disabled tests

### DIFF
--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/Transactions.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/Transactions.kt
@@ -89,12 +89,14 @@ data class InvokeFunctionPayload(
     @SerialName("function_invocation")
     val invocation: Call,
 
-    val signature: Signature?,
+    @SerialName("signature")
+    val signature: Signature,
 
     @SerialName("max_fee")
-    val maxFee: Felt?,
+    val maxFee: Felt,
 
-    val version: Felt?,
+    @SerialName("version")
+    val version: Felt,
 )
 
 class InvalidContractException(missingKey: String) :

--- a/lib/src/test/kotlin/starknet/provider/ProviderTest.kt
+++ b/lib/src/test/kotlin/starknet/provider/ProviderTest.kt
@@ -39,6 +39,14 @@ class ProviderTest {
         private fun rpcProvider(): JsonRpcProvider = JsonRpcProvider(devnetClient.rpcUrl, StarknetChainId.TESTNET)
 
         @JvmStatic
+        private fun isAccepted(receipt: TransactionReceipt): Boolean {
+            if (receipt !is AcceptedTransactionReceipt) {
+                return false
+            }
+            return receipt.status == TransactionStatus.ACCEPTED_ON_L2 || receipt.status == TransactionStatus.ACCEPTED_ON_L1
+        }
+
+        @JvmStatic
         @BeforeAll
         fun before() {
             devnetClient.start()
@@ -357,6 +365,10 @@ class ProviderTest {
         val response = request.send()
 
         assertNotNull(response)
+
+        val txrRequest = provider.getTransactionReceipt(response.transactionHash)
+        val txr = txrRequest.send()
+        assertTrue(isAccepted(txr))
     }
 
     @ParameterizedTest
@@ -371,6 +383,10 @@ class ProviderTest {
         val response = request.send()
 
         assertNotNull(response)
+
+        val txrRequest = provider.getTransactionReceipt(response.transactionHash)
+        val txr = txrRequest.send()
+        assertTrue(isAccepted(txr))
     }
 
     @ParameterizedTest
@@ -385,6 +401,10 @@ class ProviderTest {
         val response = request.send()
 
         assertNotNull(response)
+
+        val txrRequest = provider.getTransactionReceipt(response.transactionHash)
+        val txr = txrRequest.send()
+        assertTrue(isAccepted(txr))
     }
 
     @Test

--- a/lib/src/test/kotlin/starknet/provider/ProviderTest.kt
+++ b/lib/src/test/kotlin/starknet/provider/ProviderTest.kt
@@ -106,25 +106,25 @@ class ProviderTest {
     @ParameterizedTest
     @MethodSource("getProviders")
     fun `invoke transaction`(provider: Provider) {
-        // FIXME: Currently not supported in devnet
-        if (provider is JsonRpcProvider) {
-            return
-        }
+        val invokeValue = Felt(10)
 
         val call = Call(
             contractAddress,
             "increase_balance",
-            listOf(Felt(10)),
+            listOf(invokeValue),
         )
 
+        val oldBalance = devnetClient.getStorageAt(contractAddress, selectorFromName("balance"))
+
         val dummySig = listOf(Felt(0), Felt(0), Felt(0), Felt(0), Felt(0))
-        val payload = InvokeFunctionPayload(call, dummySig, Felt(0), null)
+        val payload = InvokeFunctionPayload(call, dummySig, Felt.ZERO, Felt.ZERO)
         val request = provider.invokeFunction(payload)
 
         request.send()
 
-        val balance = getBalance(provider)
-        assertEquals(Felt(10), balance)
+        val newBalance = devnetClient.getStorageAt(contractAddress, selectorFromName("balance"))
+
+        assertEquals(oldBalance.value + invokeValue.value , newBalance.value)
     }
 
     @ParameterizedTest
@@ -209,7 +209,7 @@ class ProviderTest {
     @ParameterizedTest
     @MethodSource("getProviders")
     fun `get class hash at pending block`(provider: Provider) {
-        // FIXME: Currently not supported in devnet
+        // Devnet only support's "latest" as block id in this method
         if (provider is JsonRpcProvider) {
             return
         }
@@ -223,11 +223,6 @@ class ProviderTest {
     @ParameterizedTest
     @MethodSource("getProviders")
     fun `get class hash at latest block`(provider: Provider) {
-        // FIXME: Currently not supported in devnet
-        if (provider is JsonRpcProvider) {
-            return
-        }
-
         val request = provider.getClassHashAt(contractAddress, BlockTag.LATEST)
         val response = request.send()
 
@@ -237,7 +232,7 @@ class ProviderTest {
     @ParameterizedTest
     @MethodSource("getProviders")
     fun `get class hash at block hash`(provider: Provider) {
-        // FIXME: Currently not supported in devnet
+//        // Devnet only support's "latest" as block id in this method
         if (provider is JsonRpcProvider) {
             return
         }
@@ -252,7 +247,7 @@ class ProviderTest {
     @ParameterizedTest
     @MethodSource("getProviders")
     fun `get class hash at block number`(provider: Provider) {
-        // FIXME: Currently not supported in devnet
+//        // Devnet only support's "latest" as block id in this method
         if (provider is JsonRpcProvider) {
             return
         }
@@ -291,7 +286,8 @@ class ProviderTest {
         assertTrue(response is GatewayTransactionReceipt)
     }
 
-    // FIXME(This test will fail until devnet is updated to the newest rpc spec)
+    // FIXME this test will fail until devnet spec is updated as there is no way to differentiate between declare
+    //  and deploy tx receipts currently
 //    @Test
 //    fun `get deploy transaction receipt rpc`() {
 //        val request = rpcProvider().getTransactionReceipt(deployTransactionHash)

--- a/lib/src/test/kotlin/starknet/provider/ProviderTest.kt
+++ b/lib/src/test/kotlin/starknet/provider/ProviderTest.kt
@@ -124,7 +124,7 @@ class ProviderTest {
 
         val newBalance = devnetClient.getStorageAt(contractAddress, selectorFromName("balance"))
 
-        assertEquals(oldBalance.value + invokeValue.value , newBalance.value)
+        assertEquals(oldBalance.value + invokeValue.value, newBalance.value)
     }
 
     @ParameterizedTest

--- a/lib/src/test/kotlin/starknet/provider/ProviderTest.kt
+++ b/lib/src/test/kotlin/starknet/provider/ProviderTest.kt
@@ -240,7 +240,7 @@ class ProviderTest {
     @ParameterizedTest
     @MethodSource("getProviders")
     fun `get class hash at block hash`(provider: Provider) {
-//        // Devnet only support's "latest" as block id in this method
+        // Devnet only support's "latest" as block id in this method
         if (provider is JsonRpcProvider) {
             return
         }
@@ -255,7 +255,7 @@ class ProviderTest {
     @ParameterizedTest
     @MethodSource("getProviders")
     fun `get class hash at block number`(provider: Provider) {
-//        // Devnet only support's "latest" as block id in this method
+        // Devnet only support's "latest" as block id in this method
         if (provider is JsonRpcProvider) {
             return
         }


### PR DESCRIPTION
This PR closes #59. There are some tests that remain commented out or disabled for the rpc client because of the devnet limitations. For these more descriptive comments has been added.

Tests that weren't restored subject methods that are not implemented at all and I think should be left for post the initial release. 