### PR TITLE
Add missing docs, improve existing

### DIFF
--- a/lib/src/main/kotlin/com/swmansion/starknet/data/NetUrls.java
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/NetUrls.java
@@ -1,6 +1,16 @@
 package com.swmansion.starknet.data;
 
+/**
+ * Urls of StarkNet networks.
+ */
 public final class NetUrls {
+    /**
+     * Url of StarkNet testnet
+     */
     public static final String TESTNET_URL = "https://alpha4.starknet.io";
+
+    /**
+     * Url of StarkNet mainnet
+     */
     public static final String MAINNET_URL = "https://alpha-mainnet.starknet.io";
 }

--- a/lib/src/main/kotlin/com/swmansion/starknet/provider/Provider.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/provider/Provider.kt
@@ -18,7 +18,7 @@ interface Provider {
      *
      * @param call a call to be made
      * @param blockTag
-     * 
+     *
      * @throws RequestFailedException
      */
     fun callContract(call: Call, blockTag: BlockTag): Request<CallContractResponse>

--- a/lib/src/main/kotlin/com/swmansion/starknet/provider/Provider.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/provider/Provider.kt
@@ -2,6 +2,7 @@ package com.swmansion.starknet.provider
 
 import com.swmansion.starknet.data.types.*
 import com.swmansion.starknet.data.types.transactions.*
+import com.swmansion.starknet.provider.exceptions.RequestFailedException
 
 /**
  * Provider for interacting with StarkNet.
@@ -17,6 +18,8 @@ interface Provider {
      *
      * @param call a call to be made
      * @param blockTag
+     * 
+     * @throws RequestFailedException
      */
     fun callContract(call: Call, blockTag: BlockTag): Request<CallContractResponse>
 
@@ -25,6 +28,8 @@ interface Provider {
      *
      * @param call a call to be made
      * @param blockHash a hash of the block in respect to what the call will be made
+     *
+     * @throws RequestFailedException
      */
     fun callContract(call: Call, blockHash: Felt): Request<CallContractResponse>
 
@@ -33,6 +38,8 @@ interface Provider {
      *
      * @param call a call to be made
      * @param blockNumber a number of the block in respect to what the call will be made
+     *
+     * @throws RequestFailedException
      */
     fun callContract(call: Call, blockNumber: Int): Request<CallContractResponse>
 
@@ -44,6 +51,8 @@ interface Provider {
      * @param contractAddress an address of the contract
      * @param key an address of the storage variable inside contract
      * @param blockTag
+     *
+     * @throws RequestFailedException
      */
     fun getStorageAt(contractAddress: Felt, key: Felt, blockTag: BlockTag): Request<Felt>
 
@@ -55,6 +64,8 @@ interface Provider {
      * @param contractAddress an address of the contract
      * @param key an address of the storage variable inside contract
      * @param blockHash a hash of the block in respect to what the query will be made
+     *
+     * @throws RequestFailedException
      */
     fun getStorageAt(contractAddress: Felt, key: Felt, blockHash: Felt): Request<Felt>
 
@@ -66,6 +77,8 @@ interface Provider {
      * @param contractAddress an address of the contract
      * @param key an address of the storage variable inside contract
      * @param blockNumber a number of the block in respect to what the query will be made
+     *
+     * @throws RequestFailedException
      */
     fun getStorageAt(contractAddress: Felt, key: Felt, blockNumber: Int): Request<Felt>
 
@@ -75,6 +88,8 @@ interface Provider {
      * Get the details of a submitted transaction.
      *
      * @param transactionHash a hash of sent transaction
+     *
+     * @throws RequestFailedException
      */
     fun getTransaction(transactionHash: Felt): Request<Transaction>
 
@@ -84,6 +99,8 @@ interface Provider {
      * Get a receipt of the transactions.
      *
      * @param transactionHash a hash of sent transaction
+     *
+     * @throws RequestFailedException
      */
     fun getTransactionReceipt(transactionHash: Felt): Request<out TransactionReceipt>
 
@@ -93,6 +110,8 @@ interface Provider {
      * Invoke a function in deployed contract.
      *
      * @param payload invoke function payload
+     *
+     * @throws RequestFailedException
      */
     fun invokeFunction(payload: InvokeFunctionPayload): Request<InvokeFunctionResponse>
 
@@ -102,6 +121,8 @@ interface Provider {
      * Get the contract class definition associated with the given hash.
      *
      * @param classHash The hash of the requested contract class.
+     *
+     * @throws RequestFailedException
      */
     fun getClass(classHash: Felt): Request<ContractClass>
 
@@ -114,6 +135,8 @@ interface Provider {
      *
      * @param blockNumber The number of the requested block.
      * @param contractAddress The address of the contract whose class definition will be returned.
+     *
+     * @throws RequestFailedException
      */
     fun getClassHashAt(contractAddress: Felt, blockNumber: Int): Request<Felt>
 
@@ -124,6 +147,8 @@ interface Provider {
      *
      * @param blockTag The tag of the requested block.
      * @param contractAddress The address of the contract whose class definition will be returned.
+     *
+     * @throws RequestFailedException
      */
     fun getClassHashAt(contractAddress: Felt, blockTag: BlockTag): Request<Felt>
 
@@ -133,6 +158,8 @@ interface Provider {
      * Deploy a contract on StarkNet.
      *
      * @param payload deploy transaction payload
+     *
+     * @throws RequestFailedException
      */
     fun deployContract(payload: DeployTransactionPayload): Request<DeployResponse>
 
@@ -142,6 +169,8 @@ interface Provider {
      * Declare a contract on StarkNet.
      *
      * @param payload declare transaction payload
+     *
+     * @throws RequestFailedException
      */
     fun declareContract(payload: DeclareTransactionPayload): Request<DeclareResponse>
 }

--- a/lib/src/main/kotlin/com/swmansion/starknet/provider/exceptions/GatewayRequestFailedException.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/provider/exceptions/GatewayRequestFailedException.kt
@@ -1,4 +1,11 @@
 package com.swmansion.starknet.provider.exceptions
 
+/**
+ * Exception thrown by gateway provider on request failure.
+ *
+ * @param code error code returned by the gateway
+ * @param message error message returned by the gateway
+ * @param payload payload returned by the service used to communicate with StarkNet
+ */
 class GatewayRequestFailedException(val code: Int, message: String, payload: String) :
     RequestFailedException(message = message, payload = payload)

--- a/lib/src/main/kotlin/com/swmansion/starknet/provider/exceptions/RequestFailedException.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/provider/exceptions/RequestFailedException.kt
@@ -1,3 +1,9 @@
 package com.swmansion.starknet.provider.exceptions
 
+/**
+ * Base exception for all provider errors.
+ *
+ * @param message error message
+ * @param payload payload returned by the service used to communicate with StarkNet
+ */
 open class RequestFailedException(message: String = "Request failed", val payload: String) : Exception(message)

--- a/lib/src/main/kotlin/com/swmansion/starknet/provider/exceptions/RpcRequestFailedException.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/provider/exceptions/RpcRequestFailedException.kt
@@ -1,4 +1,11 @@
 package com.swmansion.starknet.provider.exceptions
 
+/**
+ * Exception thrown by rpc provider on request failure.
+ *
+ * @param code error code returned by the rpc provider
+ * @param message error message returned by the rpc provider
+ * @param payload payload returned by the service used to communicate with StarkNet
+ */
 class RpcRequestFailedException(val code: Int, message: String, payload: String) :
     RequestFailedException(message = message, payload = payload)

--- a/lib/src/main/kotlin/com/swmansion/starknet/service/http/HttpService.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/service/http/HttpService.kt
@@ -3,12 +3,24 @@ package com.swmansion.starknet.service.http
 import kotlinx.serialization.json.JsonObject
 import java.util.concurrent.CompletableFuture
 
+/**
+ * Data class representing a completed http request.
+ *
+ * @param isSuccessful indicates if result completed with code 2xx
+ * @param code http return code
+ * @param body http return body
+ */
 data class HttpResponse(
     val isSuccessful: Boolean,
     val code: Int,
     val body: String,
 )
 
+/**
+ * Service for http communication.
+ *
+ * Implementers of this interface provide methods to facilitate http communication between Providers and StarkNet
+ */
 interface HttpService {
     data class Payload(
         val url: String,

--- a/lib/starknet-jvm.md
+++ b/lib/starknet-jvm.md
@@ -131,3 +131,48 @@ fun main() {
     future.thenAccept { println(it) }
 }
 ```
+
+# Package com.swmansion.starknet.account
+
+Account interface used to simplify preparing and signing StarkNet transactions.
+
+# Package com.swmansion.starknet.crypto
+
+Cryptography and signature related classes.
+
+# Package com.swmansion.starknet.data
+
+Data classes representing StarkNet objects and utilities for handling them.
+
+# Package com.swmansion.starknet.data.types
+
+Data classes representing StarkNet objects.
+
+# Package com.swmansion.starknet.data.types.transactions
+
+Data classes representing StarkNet transactions.
+
+# Package com.swmansion.starknet.provider
+
+Provider interface used for interacting with StarkNet.
+
+# Package com.swmansion.starknet.provider.exceptions
+
+Exceptions thrown by the StarkNet providers.
+
+# Package com.swmansion.starknet.provider.gateway
+
+Provider utilising StarkNet gateway and feeder gateway for communication with the network.
+
+# Package com.swmansion.starknet.provider.rpc
+
+Provider implementing the [JSON RPC interface](https://github.com/starkware-libs/starknet-specs)
+to communicate with the network.
+
+# Package com.swmansion.starknet.service.http
+
+Http service used in both provider to communicate with StarkNet.
+
+# Package com.swmansion.starknet.signer
+
+Signer interface used to sign StarkNet transactions.


### PR DESCRIPTION
Resolves #94 and improves documentation of already existing public objects.

Also, it turns out you can document specific packages by adding `# Package full.path.to.package` sections to `starknet-jvm.md` file so in the future we can consider adding some code examples and more more details to specific sections. Currently, I've just included basic descriptions there.