### PR TITLE
Bump devnet to 0.3.0 and update tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,10 +21,10 @@ jobs:
         uses: jwlawson/actions-setup-cmake@v1.12
         with:
           cmake-version: '3.16.x'
-      - name: Set up Python 3.7.12
+      - name: Set up Python 3.9.12
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7.12
+          python-version: 3.9.12
 
       - name: Install devnet
         run: |

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/GatewayCallContractTransformingSerializer.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/GatewayCallContractTransformingSerializer.kt
@@ -1,0 +1,14 @@
+package com.swmansion.starknet.data.serializers
+
+import com.swmansion.starknet.data.types.Felt
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonTransformingSerializer
+import kotlinx.serialization.json.jsonObject
+
+object GatewayCallContractTransformingSerializer :
+    JsonTransformingSerializer<List<Felt>>(ListSerializer(Felt.serializer())) {
+    override fun transformDeserialize(element: JsonElement): JsonElement {
+        return element.jsonObject["result"]!!
+    }
+}

--- a/lib/src/main/kotlin/com/swmansion/starknet/provider/Provider.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/provider/Provider.kt
@@ -21,7 +21,7 @@ interface Provider {
      *
      * @throws RequestFailedException
      */
-    fun callContract(call: Call, blockTag: BlockTag): Request<CallContractResponse>
+    fun callContract(call: Call, blockTag: BlockTag): Request<List<Felt>>
 
     /**
      * Calls a contract deployed on StarkNet.
@@ -31,7 +31,7 @@ interface Provider {
      *
      * @throws RequestFailedException
      */
-    fun callContract(call: Call, blockHash: Felt): Request<CallContractResponse>
+    fun callContract(call: Call, blockHash: Felt): Request<List<Felt>>
 
     /**
      * Calls a contract deployed on StarkNet.
@@ -41,7 +41,7 @@ interface Provider {
      *
      * @throws RequestFailedException
      */
-    fun callContract(call: Call, blockNumber: Int): Request<CallContractResponse>
+    fun callContract(call: Call, blockNumber: Int): Request<List<Felt>>
 
     /**
      * Get a value of storage var.

--- a/lib/src/main/kotlin/com/swmansion/starknet/provider/gateway/GatewayProvider.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/provider/gateway/GatewayProvider.kt
@@ -3,6 +3,7 @@ package com.swmansion.starknet.provider.gateway
 import com.swmansion.starknet.data.DECLARE_SENDER_ADDRESS
 import com.swmansion.starknet.data.NetUrls.MAINNET_URL
 import com.swmansion.starknet.data.NetUrls.TESTNET_URL
+import com.swmansion.starknet.data.serializers.GatewayCallContractTransformingSerializer
 import com.swmansion.starknet.data.serializers.GatewayTransactionTransformingSerializer
 import com.swmansion.starknet.data.types.*
 import com.swmansion.starknet.data.types.transactions.*
@@ -47,7 +48,7 @@ class GatewayProvider(
         return "$feederGatewayUrl/$method"
     }
 
-    private fun callContract(payload: CallContractPayload): Request<CallContractResponse> {
+    private fun callContract(payload: CallContractPayload): Request<List<Felt>> {
         val url = feederGatewayRequestUrl("call_contract")
 
         val params = listOf(Pair("blockHash", payload.blockId.toString()))
@@ -62,7 +63,7 @@ class GatewayProvider(
 
         return HttpRequest(
             Payload(url, "POST", params, body),
-            buildDeserializer(CallContractResponse.serializer()),
+            buildDeserializer(GatewayCallContractTransformingSerializer),
             httpService,
         )
     }
@@ -101,19 +102,19 @@ class GatewayProvider(
             json.decodeFromString(deserializationStrategy, body)
         }
 
-    override fun callContract(call: Call, blockTag: BlockTag): Request<CallContractResponse> {
+    override fun callContract(call: Call, blockTag: BlockTag): Request<List<Felt>> {
         val payload = CallContractPayload(call, BlockId.Tag(blockTag))
 
         return callContract(payload)
     }
 
-    override fun callContract(call: Call, blockHash: Felt): Request<CallContractResponse> {
+    override fun callContract(call: Call, blockHash: Felt): Request<List<Felt>> {
         val payload = CallContractPayload(call, BlockId.Hash(blockHash))
 
         return callContract(payload)
     }
 
-    override fun callContract(call: Call, blockNumber: Int): Request<CallContractResponse> {
+    override fun callContract(call: Call, blockNumber: Int): Request<List<Felt>> {
         val payload = CallContractPayload(call, BlockId.Number(blockNumber))
 
         return callContract(payload)

--- a/lib/src/main/kotlin/com/swmansion/starknet/provider/rpc/JsonRpcProvider.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/provider/rpc/JsonRpcProvider.kt
@@ -12,6 +12,7 @@ import com.swmansion.starknet.service.http.HttpRequest
 import com.swmansion.starknet.service.http.HttpService
 import com.swmansion.starknet.service.http.OkhttpHttpService
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.*
 
 /**
@@ -50,25 +51,25 @@ class JsonRpcProvider(
         return HttpRequest(payload, buildJsonHttpDeserializer(responseSerializer), httpService)
     }
 
-    private fun callContract(payload: CallContractPayload): Request<CallContractResponse> {
+    private fun callContract(payload: CallContractPayload): Request<List<Felt>> {
         val params = Json.encodeToJsonElement(payload)
 
-        return buildRequest(JsonRpcMethod.CALL, params, CallContractResponse.serializer())
+        return buildRequest(JsonRpcMethod.CALL, params, ListSerializer(Felt.serializer()))
     }
 
-    override fun callContract(call: Call, blockTag: BlockTag): Request<CallContractResponse> {
+    override fun callContract(call: Call, blockTag: BlockTag): Request<List<Felt>> {
         val payload = CallContractPayload(call, BlockId.Tag(blockTag))
 
         return callContract(payload)
     }
 
-    override fun callContract(call: Call, blockHash: Felt): Request<CallContractResponse> {
+    override fun callContract(call: Call, blockHash: Felt): Request<List<Felt>> {
         val payload = CallContractPayload(call, BlockId.Hash(blockHash))
 
         return callContract(payload)
     }
 
-    override fun callContract(call: Call, blockNumber: Int): Request<CallContractResponse> {
+    override fun callContract(call: Call, blockNumber: Int): Request<List<Felt>> {
         val payload = CallContractPayload(call, BlockId.Number(blockNumber))
 
         return callContract(payload)

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -68,7 +68,7 @@ class StandardAccountTest {
         // TODO: Delete after this becomes a part of Account
         fun getNonce(account: Account): Felt {
             val call = Call(contractAddress = account.address, entrypoint = "get_nonce", calldata = listOf())
-            return account.callContract(call, BlockTag.LATEST).send().result.first()
+            return account.callContract(call, BlockTag.LATEST).send().first()
         }
 
         @JvmStatic

--- a/lib/src/test/kotlin/starknet/provider/ProviderTest.kt
+++ b/lib/src/test/kotlin/starknet/provider/ProviderTest.kt
@@ -48,20 +48,24 @@ class ProviderTest {
         @JvmStatic
         @BeforeAll
         fun before() {
-            devnetClient.start()
-
-            val (deployAddress, deployHash) = devnetClient.deployContract(Path.of("src/test/resources/compiled/providerTest.json"))
-            val (_, invokeHash) = devnetClient.invokeTransaction(
-                "increase_balance",
-                deployAddress,
-                Path.of("src/test/resources/compiled/providerTestAbi.json"),
-                0,
-            )
-            val (_, declareHash) = devnetClient.declareContract(Path.of("src/test/resources/compiled/providerTest.json"))
-            contractAddress = deployAddress
-            deployTransactionHash = deployHash
-            invokeTransactionHash = invokeHash
-            declareTransactionHash = declareHash
+            try {
+                devnetClient.start()
+                val (deployAddress, deployHash) = devnetClient.deployContract(Path.of("src/test/resources/compiled/providerTest.json"))
+                val (_, invokeHash) = devnetClient.invokeTransaction(
+                    "increase_balance",
+                    deployAddress,
+                    Path.of("src/test/resources/compiled/providerTestAbi.json"),
+                    0,
+                )
+                val (_, declareHash) = devnetClient.declareContract(Path.of("src/test/resources/compiled/providerTest.json"))
+                contractAddress = deployAddress
+                deployTransactionHash = deployHash
+                invokeTransactionHash = invokeHash
+                declareTransactionHash = declareHash
+            } catch (ex: Exception) {
+                devnetClient.close()
+                throw ex
+            }
         }
 
         @JvmStatic
@@ -81,9 +85,9 @@ class ProviderTest {
         val request = provider.callContract(call, BlockTag.LATEST)
         val response = request.send()
 
-        assertEquals(1, response.result.size)
+        assertEquals(1, response.size)
 
-        return response.result.first()
+        return response.first()
     }
 
     @ParameterizedTest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-starknet-devnet==0.2.11
-
+# Replace this with pypi version once devnet releases our changes
+git+https://github.com/Shard-Labs/starknet-devnet.git@03e77ec828418ce158af2294926b62dadc406747


### PR DESCRIPTION
## Describe your changes

<!-- A brief description of the changes introduced in this PR -->

This PR bumps devnet to 0.3.0 (temporarily from github branch) and updates related tests.

This PR also simplifies return type of `Provider.callContract`.

## Linked issues

n/a

<!-- Reference any GitHub issues resolved by this PR -->

## Breaking changes

- [x] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->

Return type of `Provider.callContract` changed.
