### PR TITLE
Kill zombie devnet processes

### DIFF
--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -29,14 +29,14 @@ class StandardAccountTest {
                 devnetClient.start()
 
                 gatewayProvider = GatewayProvider(
-                        devnetClient.feederGatewayUrl,
-                        devnetClient.gatewayUrl,
-                        StarknetChainId.TESTNET,
+                    devnetClient.feederGatewayUrl,
+                    devnetClient.gatewayUrl,
+                    StarknetChainId.TESTNET,
                 )
 
                 rpcProvider = JsonRpcProvider(
-                        devnetClient.rpcUrl,
-                        StarknetChainId.TESTNET,
+                    devnetClient.rpcUrl,
+                    StarknetChainId.TESTNET,
                 )
 
                 val (deployAddress, _) = devnetClient.deployContract(Path.of("src/test/resources/compiled/providerTest.json"))

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -25,21 +25,26 @@ class StandardAccountTest {
         @JvmStatic
         @BeforeAll
         fun before() {
-            devnetClient.start()
+            try {
+                devnetClient.start()
 
-            gatewayProvider = GatewayProvider(
-                devnetClient.feederGatewayUrl,
-                devnetClient.gatewayUrl,
-                StarknetChainId.TESTNET,
-            )
+                gatewayProvider = GatewayProvider(
+                        devnetClient.feederGatewayUrl,
+                        devnetClient.gatewayUrl,
+                        StarknetChainId.TESTNET,
+                )
 
-            rpcProvider = JsonRpcProvider(
-                devnetClient.rpcUrl,
-                StarknetChainId.TESTNET,
-            )
+                rpcProvider = JsonRpcProvider(
+                        devnetClient.rpcUrl,
+                        StarknetChainId.TESTNET,
+                )
 
-            val (deployAddress, _) = devnetClient.deployContract(Path.of("src/test/resources/compiled/providerTest.json"))
-            balanceContractAddress = deployAddress
+                val (deployAddress, _) = devnetClient.deployContract(Path.of("src/test/resources/compiled/providerTest.json"))
+                balanceContractAddress = deployAddress
+            } catch (ex: Exception) {
+                devnetClient.close()
+                throw ex
+            }
         }
 
         @JvmStatic

--- a/lib/src/test/kotlin/starknet/utils/DevnetClient.kt
+++ b/lib/src/test/kotlin/starknet/utils/DevnetClient.kt
@@ -51,7 +51,7 @@ class DevnetClient(
         ProcessBuilder(
             "pkill",
             "-f",
-            "starknet-devnet.*${port}.*${seed}"
+            "starknet-devnet.*$port.*$seed",
         ).start().waitFor()
 
         devnetProcess =

--- a/lib/src/test/kotlin/starknet/utils/DevnetClient.kt
+++ b/lib/src/test/kotlin/starknet/utils/DevnetClient.kt
@@ -22,6 +22,7 @@ class DevnetClient(
 ) : AutoCloseable {
     private val accountDirectory = Paths.get("src/test/resources/account")
     private val baseUrl: String = "http://$host:$port"
+    private val seed: Int = 1053545547
 
     private lateinit var accountAddress: Felt
     private lateinit var devnetProcess: Process
@@ -45,6 +46,14 @@ class DevnetClient(
             throw DevnetSetupFailedException("Devnet is already running")
         }
 
+        // This kills any zombie devnet processes left over from previous
+        // test runs, if any.
+        ProcessBuilder(
+            "pkill",
+            "-f",
+            "starknet-devnet.*${port}.*${seed}"
+        ).start().waitFor()
+
         devnetProcess =
             ProcessBuilder(
                 "starknet-devnet",
@@ -53,7 +62,7 @@ class DevnetClient(
                 "--port",
                 port.toString(),
                 "--seed",
-                "1053545547",
+                seed.toString(),
             ).start()
 
         // TODO: Replace with reading buffer until it prints "Listening on"


### PR DESCRIPTION
## Describe your changes

Some gunicorn processes (possibly worker) sometimes do not exit when main process is being interrupted, and their processes are left dangling which in turn fails our tests. This is a workaround for the problem.

## Linked issues

https://github.com/software-mansion/starknet-jvm/issues/95

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
