### PR TITLE
Remove `internal` from `StarknetCurve

### DIFF
--- a/androiddemo/build.gradle.kts
+++ b/androiddemo/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.4.2")
     implementation("com.google.android.material:material:1.6.1")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
-    implementation("com.swmansion.starknet:starknet:0.1.0@aar")
+    implementation("com.swmansion.starknet:starknet:0.1.1@aar")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.3")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")

--- a/javademo/build.gradle.kts
+++ b/javademo/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    implementation("com.swmansion.starknet:starknet:0.1.0")
+    implementation("com.swmansion.starknet:starknet:0.1.1")
 }
 
 application {

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -8,7 +8,7 @@
 
 import org.jetbrains.dokka.gradle.DokkaTask
 
-version = "0.1.0"
+version = "0.1.1"
 group = "com.swmansion.starknet"
 
 plugins {

--- a/lib/src/main/kotlin/com/swmansion/starknet/crypto/StarknetCurve.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/crypto/StarknetCurve.kt
@@ -37,7 +37,7 @@ private fun feltToNative(input: Felt): ByteArray = bigintToNative(input.value)
  *
  * Class with utility methods related to starknet curve signatures generation and verification.
  */
-internal object StarknetCurve {
+object StarknetCurve {
 
     @field:JvmField
     val CURVE_ORDER: BigInteger = BigInteger("800000000000010FFFFFFFFFFFFFFFFB781126DCAE7B2321E66A241ADC64D2F", 16)


### PR DESCRIPTION
## Describe your changes

<!-- A brief description of the changes introduced in this PR -->

This PR removes `internal` visibility modifier from `StarknetCurve` that was accidentally added.

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
