### PR TITLE
Fix breaking whitespaces in java docs

### DIFF
--- a/.github/workflows/build-and-publish-docs.yml
+++ b/.github/workflows/build-and-publish-docs.yml
@@ -18,6 +18,11 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
+      # https://www.oracle.com/technical-resources/articles/java/javadoc-tool.html#Descriptions
+      - name: Replace whitespaces after dots with non breaking spaces.
+        # Look for '. ' or '.\newline' and replace it with '.&nbsp;'
+        run: sed -i 's/\(\.\s\|\.$\)/.\&nbsp;/g' lib/starknet-jvm.md
+
       # Build java and kotlin style docs and copy kotlin output to the java folder
       # so that the deployed github page has java docs at `/` and kotlin docs at `/kotlin`
       - name: Build docs

--- a/androiddemo/build.gradle.kts
+++ b/androiddemo/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.4.2")
     implementation("com.google.android.material:material:1.6.1")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
-    implementation("com.swmansion.starknet:starknet:0.1.2@aar")
+    implementation("com.swmansion.starknet:starknet:0.2.0@aar")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.3")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")

--- a/javademo/build.gradle.kts
+++ b/javademo/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    implementation("com.swmansion.starknet:starknet:0.1.2")
+    implementation("com.swmansion.starknet:starknet:0.2.0")
 }
 
 application {

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -8,7 +8,7 @@
 
 import org.jetbrains.dokka.gradle.DokkaTask
 
-version = "0.1.2"
+version = "0.2.0"
 group = "com.swmansion.starknet"
 
 plugins {

--- a/lib/starknet-jvm.md
+++ b/lib/starknet-jvm.md
@@ -1,9 +1,9 @@
 # Module starknet-jvm
 
-StarkNet.kt is a library allowing for easy interaction with StarkNet gateway and nodes, including
+StarkNet-jvm is a library allowing for easy interaction with StarkNet gateway and nodes, including
 querying starknet state, executing transactions and deploying contracts.
 
-Although written in Kotlin, StarkNet.kt has been created with compatibility with Java in mind.
+Although written in Kotlin, StarkNet-jvm has been created with compatibility with Java in mind.
 
 ## Making synchronous requests
 
@@ -261,7 +261,7 @@ application can use a single `OkHttpClient`. Read more [here](https://square.git
 ```java
 import com.swmansion.starknet.service.http.OkHttpService;
 
-// ...
+// (...)
 
 var httpClient = new OkHttpClient();
 var httpService = new OkHttpService(httpClient);


### PR DESCRIPTION
## Describe your changes

This is a workaround for a problem with missing extensive descriptions on java docs.
https://www.oracle.com/technical-resources/articles/java/javadoc-tool.html#Descriptions

## Linked issues

Closes https://github.com/software-mansion/starknet-jvm/issues/138

## Breaking changes

- [ ] This issue contains breaking changes
