### PR TITLE
Fix namespace shadowing on android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 android {
     compileSdk 32
-    namespace "com.swmmansion.starknet"
+    namespace "com.swmansion.starknet"
 
     defaultConfig {
         minSdk 24


### PR DESCRIPTION
> I noticed an issue with the android AAR configuration. The namespace defined shadows the android namespace which causes issues on our end. It should be sth like com.swmmansion.starknet. Here is more information about this in the official docs https://developer.android.com/studio/publish-library/prep-lib-release#choose-namespace. Could u please adjust that and deploy a fix?