### PR TITLE
:bug: Fixing callContract when block id is a number or a tag

### DIFF
--- a/lib/src/main/kotlin/com/swmansion/starknet/provider/gateway/GatewayProvider.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/provider/gateway/GatewayProvider.kt
@@ -58,7 +58,10 @@ class GatewayProvider(
     private fun callContract(payload: CallContractPayload): Request<List<Felt>> {
         val url = feederGatewayRequestUrl("call_contract")
 
-        val params = listOf(Pair("blockHash", payload.blockId.toString()))
+        val params = when (payload.blockId) {
+            is BlockId.Hash -> listOf(Pair("blockHash", payload.blockId.toString()))
+            is BlockId.Number, is BlockId.Tag -> listOf(Pair("blockNumber", payload.blockId.toString()))
+        }
 
         val decimalCalldata = Json.encodeToJsonElement(payload.request.calldata.toDecimal())
         val body = buildJsonObject {


### PR DESCRIPTION
## Describe your changes

GatewayProvider.callContract fails when using blockTag or blockNumber. It always sends `blockHash` even if the block id is a number or a tag.

## Linked issues

Closes --> https://github.com/software-mansion/starknet-jvm/issues/154
