### PR TITLE
Use java 11 compatible code in javademo

### DIFF
--- a/javademo/src/main/java/com/example/javademo/Main.java
+++ b/javademo/src/main/java/com/example/javademo/Main.java
@@ -15,13 +15,13 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class Main {
     public static void main(String[] args) throws Exception {
         // Set up an account
         Felt address = Felt.fromHex("0x1234");
-        Felt privateKey = new Felt(new Random().nextLong(1, Long.MAX_VALUE));
+        Felt privateKey = new Felt(ThreadLocalRandom.current().nextLong(1, Long.MAX_VALUE));
         Provider provider = GatewayProvider.makeTestnetClient();
         Account account = new StandardAccount(address, privateKey, provider);
 


### PR DESCRIPTION
## Describe your changes

<!-- A brief description of the changes introduced in this PR -->

This PR replaces `Random` with `ThreadLocalRandom` because as it turns out, `Random.nextLong(loweBound, upperBound)` is not available in java 11.

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
