### PR TITLE
Fix running synchronous action on Future coming from OkHttp

### DIFF
--- a/lib/src/main/kotlin/com/swmansion/starknet/service/http/HttpRequest.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/service/http/HttpRequest.kt
@@ -21,6 +21,6 @@ internal class HttpRequest<T>(
     }
 
     override fun sendAsync(): CompletableFuture<T> {
-        return service.sendAsync(payload).thenApply(deserialize)
+        return service.sendAsync(payload).thenApplyAsync(deserialize)
     }
 }


### PR DESCRIPTION
Currently `thenApply` causes `deserialize` to run synchronously after future is resolved in OkHttp thread.