### PR TITLE
Add ConvertibleToTransactionPayload interface

### DIFF
--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/Transaction.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/Transaction.kt
@@ -34,6 +34,21 @@ sealed class Transaction {
     abstract val type: TransactionType
 }
 
+/**
+ * Implementers of this interface allow conversion to the
+ * [com.swmansion.starknet.data.types.transactions.TransactionPayload] type to be used in Providers
+ *
+ * @param T: Subclass of the TransactionPayload that will be returned by the conversion
+ */
+interface ConvertibleToTransactionPayload<T : TransactionPayload> {
+    /**
+     * Convert class to payload
+     *
+     * @return a payload
+     */
+    fun toPayload(): T
+}
+
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable
 @SerialName("DEPLOY")
@@ -101,8 +116,8 @@ data class InvokeTransaction(
     override val nonce: Felt,
 
     override val type: TransactionType = TransactionType.INVOKE,
-) : Transaction() {
-    fun toPayload(): InvokeFunctionPayload {
+) : Transaction(), ConvertibleToTransactionPayload<InvokeFunctionPayload> {
+    override fun toPayload(): InvokeFunctionPayload {
         val invocation = Call(
             contractAddress = contractAddress,
             calldata = calldata,

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/TransactionPayload.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/TransactionPayload.kt
@@ -4,6 +4,8 @@ import com.swmansion.starknet.data.types.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+sealed class TransactionPayload
+
 @Serializable
 data class InvokeFunctionPayload(
     @SerialName("function_invocation")
@@ -20,14 +22,14 @@ data class InvokeFunctionPayload(
 
     @SerialName("nonce")
     val nonce: Felt,
-)
+) : TransactionPayload()
 
 data class DeployTransactionPayload(
     val contractDefinition: ContractDefinition,
     val salt: Felt,
     val constructorCalldata: Calldata,
     val version: Felt,
-)
+) : TransactionPayload()
 
 data class DeclareTransactionPayload(
     val contractDefinition: ContractDefinition,
@@ -35,4 +37,4 @@ data class DeclareTransactionPayload(
     val nonce: Felt,
     val signature: Signature,
     val version: Felt,
-)
+) : TransactionPayload()


### PR DESCRIPTION
## Describe your changes

<!-- A brief description of the changes introduced in this PR -->

This PR attempts to standardize the behavior of `toPayload` method in Transactions by adding `ConvertibleToTransactionPayload` (subject to change) interface that indicates if Transaction (or any object for that matter) is convertible to `TransactionPayload` object. 

This PR is a suggestion, if the used approach is not preferred by other developers, it can be closed.

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
