### PR TITLE
Remove support for making invoke transactions with version 0

### DIFF
--- a/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
@@ -41,12 +41,11 @@ class StandardAccount(
         val calldata = callsToExecuteCalldata(calls)
         val tx = TransactionFactory.makeInvokeTransaction(
             contractAddress = address,
-            entryPointSelector = selectorFromName(EXECUTE_ENTRY_POINT_NAME),
             calldata = calldata,
+            entryPointSelector = selectorFromName(EXECUTE_ENTRY_POINT_NAME),
             chainId = provider.chainId,
-            maxFee = params.maxFee,
             nonce = params.nonce,
-            version = version,
+            maxFee = params.maxFee,
         )
 
         val signedTransaction = tx.copy(signature = signer.signTransaction(tx))
@@ -123,10 +122,9 @@ class StandardAccount(
             calldata = payload.invocation.calldata,
             entryPointSelector = payload.invocation.entrypoint,
             chainId = provider.chainId,
-            maxFee = payload.maxFee,
-            version = payload.version,
-            signature = payload.signature,
             nonce = nonce,
+            maxFee = payload.maxFee,
+            signature = payload.signature,
         )
 
         return provider.getEstimateFee(signedTransaction, BlockTag.LATEST)

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/Transaction.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/Transaction.kt
@@ -7,6 +7,8 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonNames
 
+internal val INVOKE_VERSION = Felt.ONE
+
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable
 enum class TransactionType(val txPrefix: Felt) {
@@ -116,7 +118,6 @@ data class InvokeTransaction(
             invocation = invocation,
             signature = signature,
             maxFee = maxFee,
-            version = version,
             nonce = nonce,
         )
     }
@@ -253,7 +254,6 @@ object TransactionFactory {
         calldata: Calldata,
         entryPointSelector: Felt,
         chainId: StarknetChainId,
-        version: Felt,
         nonce: Felt,
         maxFee: Felt = Felt.ZERO,
         signature: Signature = emptyList(),
@@ -262,12 +262,12 @@ object TransactionFactory {
             contractAddress = contractAddress,
             calldata = calldata,
             chainId = chainId,
-            version = version,
+            version = INVOKE_VERSION,
             nonce = nonce,
             maxFee = maxFee,
         )
 
-        return InvokeTransaction(contractAddress, calldata, entryPointSelector, hash, maxFee, version, signature, nonce)
+        return InvokeTransaction(contractAddress, calldata, entryPointSelector, hash, maxFee, INVOKE_VERSION, signature, nonce)
     }
 
     @JvmStatic

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/Transaction.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/Transaction.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonNames
 
+@JvmSynthetic
 internal val INVOKE_VERSION = Felt.ONE
 
 @OptIn(ExperimentalSerializationApi::class)

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/TransactionPayload.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/TransactionPayload.kt
@@ -4,8 +4,9 @@ import com.swmansion.starknet.data.types.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+@Suppress("DataClassPrivateConstructor")
 @Serializable
-data class InvokeFunctionPayload(
+data class InvokeFunctionPayload private constructor(
     @SerialName("function_invocation")
     val invocation: Call,
 
@@ -20,7 +21,15 @@ data class InvokeFunctionPayload(
 
     @SerialName("nonce")
     val nonce: Felt,
-)
+) {
+    constructor(invocation: Call, signature: Signature, maxFee: Felt, nonce: Felt) : this(
+        invocation,
+        signature,
+        maxFee,
+        INVOKE_VERSION,
+        nonce,
+    )
+}
 
 data class DeployTransactionPayload(
     val contractDefinition: ContractDefinition,

--- a/lib/src/test/kotlin/starknet/data/types/TransactionsTest.kt
+++ b/lib/src/test/kotlin/starknet/data/types/TransactionsTest.kt
@@ -13,23 +13,19 @@ internal class TransactionsTest {
     @Test
     fun getHash() {
         val tx1 = TransactionFactory.makeInvokeTransaction(
-            version = Felt.ZERO,
             contractAddress = Felt.fromHex("0x2a"),
-            entryPointSelector = Felt.fromHex("0x64"),
             calldata = listOf(),
-            maxFee = Felt.ZERO,
+            entryPointSelector = Felt.fromHex("0x64"),
             chainId = StarknetChainId.TESTNET,
             nonce = Felt.ZERO,
+            maxFee = Felt.ZERO,
         )
 
-        assertEquals(Felt.fromHex("0x5d38f824da44cdde32b52b3932e7c327be1648bb770b117faa94aef71db8c5"), tx1.hash)
+        assertEquals(Felt.fromHex("0x22294fe217f962c39e4cb694a5db3f71e1132988451a9b2abc2d2ea8512088e"), tx1.hash)
 
         val tx2 = TransactionFactory.makeInvokeTransaction(
             contractAddress = Felt(
                 BigInteger("468485892896389608042320470922610020674017592380673471682128582128678525733"),
-            ),
-            entryPointSelector = Felt(
-                BigInteger("617075754465154585683856897856256838130216341506379215893724690153393808813"),
             ),
             calldata = listOf(
                 Felt(BigInteger("1")),
@@ -49,13 +45,15 @@ internal class TransactionsTest {
                     BigInteger("2"),
                 ),
             ),
+            entryPointSelector = Felt(
+                BigInteger("617075754465154585683856897856256838130216341506379215893724690153393808813"),
+            ),
             chainId = StarknetChainId.TESTNET,
-            maxFee = Felt(BigInteger("100000000")),
-            version = Felt(BigInteger("0")),
             nonce = Felt.ZERO,
+            maxFee = Felt(BigInteger("100000000")),
         )
 
-        assertEquals(Felt.fromHex("0x1bce9c419e15ad8715e7487efbefb660cc9201a25c82e98f6371928cb923fa"), tx2.hash)
+        assertEquals(Felt.fromHex("0xff63c84949d3ab0ced753c227528493dea3dc4680c65c1facb7f86ae0472df"), tx2.hash)
     }
 
     @Test


### PR DESCRIPTION
## Describe your changes

<!-- A brief description of the changes introduced in this PR -->

This PR removes support for making InvokeTransactionPayloads and InvokeTransactions through TransactionFactory with version != 1. 

Version parameter is still exposed in InvokeTransaction data class for the use in serialization.

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #147 

## Breaking changes

- [x] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->

Invoke transactions with version 0
