### PR TITLE
Make `getEstimateFee` accept `InvokeTransactionPayload`

### DIFF
--- a/lib/src/main/kotlin/com/swmansion/starknet/account/Account.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/account/Account.kt
@@ -21,7 +21,7 @@ interface Account {
      * @param params additional execution parameters for the transaction
      * @return signed invoke function payload
      */
-    fun sign(call: Call, params: ExecutionParams): InvokeFunctionPayload {
+    fun sign(call: Call, params: ExecutionParams): InvokeTransactionPayload {
         return sign(listOf(call), params)
     }
 
@@ -34,7 +34,7 @@ interface Account {
      * @param params additional execution parameters for the transaction
      * @return signed invoke function payload
      */
-    fun sign(calls: List<Call>, params: ExecutionParams): InvokeFunctionPayload
+    fun sign(calls: List<Call>, params: ExecutionParams): InvokeTransactionPayload
 
     /**
      * Sign deploy account transaction.

--- a/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
@@ -37,7 +37,7 @@ class StandardAccount(
         provider,
     )
 
-    override fun sign(calls: List<Call>, params: ExecutionParams): InvokeFunctionPayload {
+    override fun sign(calls: List<Call>, params: ExecutionParams): InvokeTransactionPayload {
         val calldata = callsToExecuteCalldata(calls)
         val tx = TransactionFactory.makeInvokeTransaction(
             contractAddress = address,

--- a/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
@@ -127,6 +127,6 @@ class StandardAccount(
             signature = payload.signature,
         )
 
-        return provider.getEstimateFee(signedTransaction, BlockTag.LATEST)
+        return provider.getEstimateFee(signedTransaction.toPayload(), BlockTag.LATEST)
     }
 }

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/Transaction.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/Transaction.kt
@@ -122,6 +122,22 @@ data class InvokeTransaction(
             nonce = nonce,
         )
     }
+
+    companion object {
+        @JvmStatic
+        internal fun fromPayload(payload: InvokeTransactionPayload): InvokeTransaction {
+            return InvokeTransaction(
+                contractAddress = payload.invocation.contractAddress,
+                calldata = payload.invocation.calldata,
+                entryPointSelector = payload.invocation.entrypoint,
+                hash = Felt.ZERO,
+                maxFee = payload.maxFee,
+                version = payload.version,
+                signature = payload.signature,
+                nonce = payload.nonce,
+            )
+        }
+    }
 }
 
 @OptIn(ExperimentalSerializationApi::class)
@@ -268,7 +284,16 @@ object TransactionFactory {
             maxFee = maxFee,
         )
 
-        return InvokeTransaction(contractAddress, calldata, entryPointSelector, hash, maxFee, INVOKE_VERSION, signature, nonce)
+        return InvokeTransaction(
+            contractAddress,
+            calldata,
+            entryPointSelector,
+            hash,
+            maxFee,
+            INVOKE_VERSION,
+            signature,
+            nonce,
+        )
     }
 
     @JvmStatic

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/Transaction.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/Transaction.kt
@@ -108,14 +108,14 @@ data class InvokeTransaction(
 
     override val type: TransactionType = TransactionType.INVOKE,
 ) : Transaction() {
-    fun toPayload(): InvokeFunctionPayload {
+    fun toPayload(): InvokeTransactionPayload {
         val invocation = Call(
             contractAddress = contractAddress,
             calldata = calldata,
             entrypoint = entryPointSelector,
         )
 
-        return InvokeFunctionPayload(
+        return InvokeTransactionPayload(
             invocation = invocation,
             signature = signature,
             maxFee = maxFee,

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/TransactionPayload.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/TransactionPayload.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 
 @Suppress("DataClassPrivateConstructor")
 @Serializable
-data class InvokeFunctionPayload private constructor(
+data class InvokeTransactionPayload private constructor(
     @SerialName("function_invocation")
     val invocation: Call,
 

--- a/lib/src/main/kotlin/com/swmansion/starknet/provider/Provider.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/provider/Provider.kt
@@ -228,40 +228,40 @@ interface Provider {
      *
      * Estimate a fee for a provided transaction.
      *
-     * @param request invoke transaction, for which the fee is to be estimated.
+     * @param payload invoke transaction, for which the fee is to be estimated.
      * @param blockHash a hash of the block in respect to what the query will be made
      */
-    fun getEstimateFee(request: InvokeTransaction, blockHash: Felt): Request<EstimateFeeResponse>
+    fun getEstimateFee(payload: InvokeTransactionPayload, blockHash: Felt): Request<EstimateFeeResponse>
 
     /**
      * Estimate a fee.
      *
      * Estimate a fee for a provided transaction.
      *
-     * @param request invoke transaction, for which the fee is to be estimated.
+     * @param payload invoke transaction, for which the fee is to be estimated.
      * @param blockNumber a number of the block in respect to what the query will be made
      */
-    fun getEstimateFee(request: InvokeTransaction, blockNumber: Int): Request<EstimateFeeResponse>
+    fun getEstimateFee(payload: InvokeTransactionPayload, blockNumber: Int): Request<EstimateFeeResponse>
 
     /**
      * Estimate a fee.
      *
      * Estimate a fee for a provided transaction.
      *
-     * @param request invoke transaction, for which the fee is to be estimated.
+     * @param payload invoke transaction, for which the fee is to be estimated.
      * @param blockTag a tag of the block in respect to what the query will be made
      */
-    fun getEstimateFee(request: InvokeTransaction, blockTag: BlockTag): Request<EstimateFeeResponse>
+    fun getEstimateFee(payload: InvokeTransactionPayload, blockTag: BlockTag): Request<EstimateFeeResponse>
 
     /**
      * Estimate a fee.
      *
      * Estimate a fee for a provided transaction in the latest block.
      *
-     * @param request invoke transaction, for which the fee is to be estimated.
+     * @param payload invoke transaction, for which the fee is to be estimated.
      */
-    fun getEstimateFee(request: InvokeTransaction): Request<EstimateFeeResponse> {
-        return getEstimateFee(request, BlockTag.LATEST)
+    fun getEstimateFee(payload: InvokeTransactionPayload): Request<EstimateFeeResponse> {
+        return getEstimateFee(payload, BlockTag.LATEST)
     }
 
     /**

--- a/lib/src/main/kotlin/com/swmansion/starknet/provider/Provider.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/provider/Provider.kt
@@ -140,7 +140,7 @@ interface Provider {
      *
      * @throws RequestFailedException
      */
-    fun invokeFunction(payload: InvokeFunctionPayload): Request<InvokeFunctionResponse>
+    fun invokeFunction(payload: InvokeTransactionPayload): Request<InvokeFunctionResponse>
 
     /**
      * Get the contract class definition.

--- a/lib/src/main/kotlin/com/swmansion/starknet/provider/gateway/GatewayProvider.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/provider/gateway/GatewayProvider.kt
@@ -286,20 +286,20 @@ class GatewayProvider(
         return getClassHashAt(param, contractAddress)
     }
 
-    // TODO: Accept payload instead of tx
     // TODO: Move serialization to a method
     private fun getEstimateFee(
-        request: InvokeTransaction,
+        payload: InvokeTransactionPayload,
         blockId: BlockId,
     ): Request<EstimateFeeResponse> {
         val url = feederGatewayRequestUrl("estimate_fee")
         val body = buildJsonObject {
             put("type", "INVOKE_FUNCTION")
-            put("contract_address", request.contractAddress.hexString())
-            putJsonArray("calldata") { request.calldata.toDecimal().forEach { add(it) } }
-            putJsonArray("signature") { request.signature.toDecimal().forEach { add(it) } }
-            put("nonce", request.nonce)
-            put("version", request.version)
+            put("contract_address", payload.invocation.contractAddress.hexString())
+            putJsonArray("calldata") { payload.invocation.calldata.toDecimal().forEach { add(it) } }
+            put("max_fee", payload.maxFee.hexString())
+            putJsonArray("signature") { payload.signature.toDecimal().forEach { add(it) } }
+            put("nonce", payload.nonce)
+            put("version", payload.version)
         }
 
         val httpPayload = Payload(url, "POST", listOf(blockId.toGatewayParam()), body)
@@ -311,16 +311,16 @@ class GatewayProvider(
         )
     }
 
-    override fun getEstimateFee(request: InvokeTransaction, blockHash: Felt): Request<EstimateFeeResponse> {
-        return getEstimateFee(request, BlockId.Hash(blockHash))
+    override fun getEstimateFee(payload: InvokeTransactionPayload, blockHash: Felt): Request<EstimateFeeResponse> {
+        return getEstimateFee(payload, BlockId.Hash(blockHash))
     }
 
-    override fun getEstimateFee(request: InvokeTransaction, blockNumber: Int): Request<EstimateFeeResponse> {
-        return getEstimateFee(request, BlockId.Number(blockNumber))
+    override fun getEstimateFee(payload: InvokeTransactionPayload, blockNumber: Int): Request<EstimateFeeResponse> {
+        return getEstimateFee(payload, BlockId.Number(blockNumber))
     }
 
-    override fun getEstimateFee(request: InvokeTransaction, blockTag: BlockTag): Request<EstimateFeeResponse> {
-        return getEstimateFee(request, BlockId.Tag(blockTag))
+    override fun getEstimateFee(payload: InvokeTransactionPayload, blockTag: BlockTag): Request<EstimateFeeResponse> {
+        return getEstimateFee(payload, BlockId.Tag(blockTag))
     }
 
     private fun getEstimateFee(

--- a/lib/src/main/kotlin/com/swmansion/starknet/provider/gateway/GatewayProvider.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/provider/gateway/GatewayProvider.kt
@@ -175,7 +175,7 @@ class GatewayProvider(
         )
     }
 
-    override fun invokeFunction(payload: InvokeFunctionPayload): Request<InvokeFunctionResponse> {
+    override fun invokeFunction(payload: InvokeTransactionPayload): Request<InvokeFunctionResponse> {
         val url = gatewayRequestUrl("add_transaction")
 
         val body = buildJsonObject {

--- a/lib/src/main/kotlin/com/swmansion/starknet/provider/rpc/JsonRpcProvider.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/provider/rpc/JsonRpcProvider.kt
@@ -125,7 +125,7 @@ class JsonRpcProvider(
     }
 
     override fun invokeFunction(
-        payload: InvokeFunctionPayload,
+        payload: InvokeTransactionPayload,
     ): Request<InvokeFunctionResponse> {
         val params = Json.encodeToJsonElement(payload)
 

--- a/lib/src/main/kotlin/com/swmansion/starknet/provider/rpc/JsonRpcProvider.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/provider/rpc/JsonRpcProvider.kt
@@ -317,20 +317,20 @@ class JsonRpcProvider(
         return buildRequest(JsonRpcMethod.ESTIMATE_FEE, jsonPayload, EstimateFeeResponse.serializer())
     }
 
-    override fun getEstimateFee(request: InvokeTransaction, blockHash: Felt): Request<EstimateFeeResponse> {
-        val payload = EstimateFeePayload(request, BlockId.Hash(blockHash))
+    override fun getEstimateFee(payload: InvokeTransactionPayload, blockHash: Felt): Request<EstimateFeeResponse> {
+        val payload = EstimateFeePayload(InvokeTransaction.fromPayload(payload), BlockId.Hash(blockHash))
 
         return getEstimateFee(payload)
     }
 
-    override fun getEstimateFee(request: InvokeTransaction, blockNumber: Int): Request<EstimateFeeResponse> {
-        val payload = EstimateFeePayload(request, BlockId.Number(blockNumber))
+    override fun getEstimateFee(payload: InvokeTransactionPayload, blockNumber: Int): Request<EstimateFeeResponse> {
+        val payload = EstimateFeePayload(InvokeTransaction.fromPayload(payload), BlockId.Number(blockNumber))
 
         return getEstimateFee(payload)
     }
 
-    override fun getEstimateFee(request: InvokeTransaction, blockTag: BlockTag): Request<EstimateFeeResponse> {
-        val payload = EstimateFeePayload(request, BlockId.Tag(blockTag))
+    override fun getEstimateFee(payload: InvokeTransactionPayload, blockTag: BlockTag): Request<EstimateFeeResponse> {
+        val payload = EstimateFeePayload(InvokeTransaction.fromPayload(payload), BlockId.Tag(blockTag))
 
         return getEstimateFee(payload)
     }


### PR DESCRIPTION
## Describe your changes

<!-- A brief description of the changes introduced in this PR -->

This PR changes Provider interface so that `getEstimateFee` accepts `InvokeTransactionPayload` instead of `InvokeTransaction`.

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #174 

## Breaking changes

- [x] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->

* Changes to the Provider interface
