### PR TITLE
Feat/address checksum

### DIFF
--- a/lib/src/main/kotlin/com/swmansion/starknet/crypto/Keccak.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/crypto/Keccak.kt
@@ -12,7 +12,7 @@ private val MASK_250 = BigInteger.valueOf(2).pow(250) - BigInteger.ONE
 /**
  * Compute a keccak hash.
  *
- * Computes a keccak of provided and applies 250bit mask to fit it in a felt.
+ * Computes a keccak of provided input and applies 250bit mask to fit it in a felt.
  *
  * @param input a ByteArray from which keccak will be generated
  * @return a felt with computed keccak

--- a/lib/src/main/kotlin/com/swmansion/starknet/crypto/Keccak.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/crypto/Keccak.kt
@@ -10,16 +10,26 @@ import java.math.BigInteger
 private val MASK_250 = BigInteger.valueOf(2).pow(250) - BigInteger.ONE
 
 /**
- * Compute a keccak.
+ * Compute a keccak hash.
  *
- * Computes a keccak of provided input.
+ * Computes a keccak of provided and applies 250bit mask to fit it in felt.
  *
  * @param input a ByteArray from which keccak will be generated
  * @return a felt with computed keccak
  */
-fun keccak(input: ByteArray): Felt {
+fun starknetKeccak(input: ByteArray): Felt = keccak(input).and(MASK_250).toFelt
+
+/**
+ * Compute a keccak hash.
+ *
+ * Computes a keccak of provided input.
+ *
+ * @param input a ByteArray from which keccak will be generated
+ * @return a big integer with computed keccak
+ */
+fun keccak(input: ByteArray): BigInteger {
     val keccak = Keccak.Digest256().apply {
         update(input)
     }
-    return BigInteger(keccak.digest()).and(MASK_250).toFelt
+    return BigInteger(keccak.digest())
 }

--- a/lib/src/main/kotlin/com/swmansion/starknet/crypto/Keccak.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/crypto/Keccak.kt
@@ -12,7 +12,7 @@ private val MASK_250 = BigInteger.valueOf(2).pow(250) - BigInteger.ONE
 /**
  * Compute a keccak hash.
  *
- * Computes a keccak of provided and applies 250bit mask to fit it in felt.
+ * Computes a keccak of provided and applies 250bit mask to fit it in a felt.
  *
  * @param input a ByteArray from which keccak will be generated
  * @return a felt with computed keccak

--- a/lib/src/main/kotlin/com/swmansion/starknet/crypto/StarknetCurve.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/crypto/StarknetCurve.kt
@@ -1,6 +1,7 @@
 package com.swmansion.starknet.crypto
 
 import com.swmansion.starknet.data.types.Felt
+import com.swmansion.starknet.extensions.toBytes
 import com.swmansion.starknet.extensions.toFelt
 import org.bouncycastle.crypto.digests.SHA256Digest
 import org.bouncycastle.crypto.signers.HMacDSAKCalculator
@@ -15,7 +16,7 @@ import java.math.BigInteger
  * @return small endian byte array
  */
 private fun bigintToNative(input: BigInteger): ByteArray {
-    val converted = input.toByteArray().apply { reverse() }
+    val converted = input.toBytes().apply { reverse() }
     if (converted.size == 32) {
         return converted
     }
@@ -128,7 +129,7 @@ object StarknetCurve {
     @JvmStatic
     fun sign(privateKey: Felt, hash: Felt): StarknetCurveSignature {
         val cal = HMacDSAKCalculator(SHA256Digest()).apply {
-            init(CURVE_ORDER, privateKey.value, hash.value.toByteArray())
+            init(CURVE_ORDER, privateKey.value, hash.value.toBytes())
         }
 
         // Generated K might not be suitable for signing. Probability of it is very low.

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/ContractAddressCalculator.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/ContractAddressCalculator.kt
@@ -87,7 +87,7 @@ object ContractAddressCalculator {
         for (i in chars.indices) {
             // We subtract from 256, because we use bits starting from the end
             if (chars[i].isLetter() && hashed.testBit(256 - 4 * i - 1)) {
-                chars[i] = chars[i].uppercase(Locale.ENGLISH)[0]
+                chars[i] = chars[i].uppercaseChar()
             }
         }
 

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/ContractAddressCalculator.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/ContractAddressCalculator.kt
@@ -1,8 +1,11 @@
 package com.swmansion.starknet.data
 
 import com.swmansion.starknet.crypto.StarknetCurve
+import com.swmansion.starknet.crypto.keccak
 import com.swmansion.starknet.data.types.Calldata
 import com.swmansion.starknet.data.types.Felt
+import java.math.BigInteger
+import java.util.*
 
 /**
  * Toolkit offering address related functionalities.
@@ -53,4 +56,39 @@ object ContractAddressCalculator {
         salt = salt,
         deployerAddress = Felt.ZERO,
     )
+
+    @JvmStatic
+    fun isChecksumAddressValid(address: String): Boolean {
+        return calculateChecksumAddress(Felt.fromHex(address)) == address
+    }
+
+    @JvmStatic
+    fun calculateChecksumAddress(address: Felt): String {
+        val stringAddress = address.value.toString(16).lowercase(Locale.ENGLISH).padStart(64, '0')
+        val chars = stringAddress.toCharArray()
+        println("ADDRESS")
+        println(stringAddress)
+        println("SIZE")
+        println(stringAddress.toByteArray(Charsets.US_ASCII).size)
+        val hashed = keccak(BigInteger(stringAddress, 16).toByteArray()).toByteArray()
+        println("HASHED")
+        println(hashed)
+//        println(hashed.toString(16))
+
+//        for (i in chars.indices) {
+//            // We subtract from 256, because we use bits starting from the end
+//            if (chars[i].isLetter() && hashed.testBit(256 - 4*i - 1 )) {
+//                chars[i] = chars[i].uppercase(Locale.ENGLISH)[0]
+//            }
+//        }
+
+        for (i in chars.indices) {
+            // We subtract from 256, because we use bits starting from the end
+            if (chars[i].isLetter() && Integer.parseInt(hashed[i].toString(), 16) >= 8) {
+                chars[i] = chars[i].uppercase(Locale.ENGLISH)[0]
+            }
+        }
+
+        return "0x${chars.concatToString()}"
+    }
 }

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/Selector.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/Selector.kt
@@ -2,7 +2,7 @@
 
 package com.swmansion.starknet.data
 
-import com.swmansion.starknet.crypto.keccak
+import com.swmansion.starknet.crypto.starknetKeccak
 import com.swmansion.starknet.data.types.Felt
 
 const val DEFAULT_ENTRY_POINT_NAME = "__default__"
@@ -20,5 +20,5 @@ fun selectorFromName(name: String): Felt {
     if (name == DEFAULT_ENTRY_POINT_NAME || name == DEFAULT_L1_ENTRY_POINT_NAME) {
         return Felt(DEFAULT_ENTRY_POINT_SELECTOR)
     }
-    return keccak(name.toByteArray(Charsets.US_ASCII))
+    return starknetKeccak(name.toByteArray(Charsets.US_ASCII))
 }

--- a/lib/src/main/kotlin/com/swmansion/starknet/extensions/BigInteger.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/extensions/BigInteger.kt
@@ -6,3 +6,16 @@ import java.math.BigInteger
 @get:JvmSynthetic
 val BigInteger.toFelt: Felt
     get() = Felt(this)
+
+@JvmSynthetic
+internal fun BigInteger.toBytes(): ByteArray {
+    require(this.signum() != -1) { "Creating ByteArray from negative numbers is not supported." }
+    val bitLength = this.bitLength()
+    // Big integer calculates byte length as bitLength()/8 + 1 to add sign.
+    // This means that if value could be represented with exactly N bytes the BigInteger
+    // will use N+1 bytes. Additional byte is important when doing hashing.
+    if (bitLength != 0 && bitLength % 8 == 0) {
+        return this.toByteArray().drop(1).toByteArray()
+    }
+    return this.toByteArray()
+}

--- a/lib/src/test/kotlin/com/swmansion/starknet/data/ContractAddressCalculatorTest.kt
+++ b/lib/src/test/kotlin/com/swmansion/starknet/data/ContractAddressCalculatorTest.kt
@@ -7,11 +7,10 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.math.BigInteger
-import java.util.*
 
 data class ChecksumTestCase(
-    val incorrect: String,
-    val correct: String,
+    val notFormatted: String,
+    val formatted: String,
 )
 
 internal class ContractAddressCalculatorTest {
@@ -78,19 +77,19 @@ internal class ContractAddressCalculatorTest {
     @MethodSource("checksumAddresses")
     fun `calculateChecksumAddress returns proper addresses`(case: ChecksumTestCase) {
         assertEquals(
-            case.correct,
-            ContractAddressCalculator.calculateChecksumAddress(Felt.fromHex(case.incorrect)),
+            case.formatted,
+            ContractAddressCalculator.calculateChecksumAddress(Felt.fromHex(case.notFormatted)),
         )
         assertEquals(
-            case.correct,
-            ContractAddressCalculator.calculateChecksumAddress(Felt.fromHex(case.correct)),
+            case.formatted,
+            ContractAddressCalculator.calculateChecksumAddress(Felt.fromHex(case.formatted)),
         )
     }
 
     @ParameterizedTest
     @MethodSource("checksumAddresses")
     fun `isChecksumAddressValid works`(case: ChecksumTestCase) {
-        assertTrue(ContractAddressCalculator.isChecksumAddressValid(case.correct))
-        assertFalse(ContractAddressCalculator.isChecksumAddressValid(case.incorrect))
+        assertTrue(ContractAddressCalculator.isChecksumAddressValid(case.formatted))
+        assertFalse(ContractAddressCalculator.isChecksumAddressValid(case.notFormatted))
     }
 }

--- a/lib/src/test/kotlin/com/swmansion/starknet/data/ContractAddressCalculatorTest.kt
+++ b/lib/src/test/kotlin/com/swmansion/starknet/data/ContractAddressCalculatorTest.kt
@@ -1,15 +1,45 @@
 package com.swmansion.starknet.data
 
+import com.swmansion.starknet.crypto.keccak
 import com.swmansion.starknet.data.types.Felt
 import com.swmansion.starknet.extensions.toFelt
+import org.bouncycastle.jcajce.provider.digest.Keccak
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import java.math.BigInteger
+import java.util.*
+
+data class ChecksumTestCase(
+    val incorrect: String,
+    val correct: String,
+)
 
 internal class ContractAddressCalculatorTest {
-    private val classHash = BigInteger("951442054899045155353616354734460058868858519055082696003992725251069061570").toFelt
+    private val classHash =
+        BigInteger("951442054899045155353616354734460058868858519055082696003992725251069061570").toFelt
     private val constructorCalldata = listOf(Felt(21), Felt(37))
     private val salt = Felt(1111)
+
+    companion object {
+        // List of (address, valid checksum address)
+        @JvmStatic
+        fun checksumAddresses() = listOf(
+            ChecksumTestCase(
+                "0x2fd23d9182193775423497fc0c472e156c57c69e4089a1967fb288a2d84e914",
+                "0x02Fd23d9182193775423497fc0c472E156C57C69E4089A1967fb288A2d84e914",
+            ),
+            ChecksumTestCase(
+                "0x00abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefab",
+                "0x00AbcDefaBcdefabCDEfAbCDEfAbcdEFAbCDEfabCDefaBCdEFaBcDeFaBcDefAb",
+            ),
+            ChecksumTestCase(
+                "0xfedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcbafe",
+                "0x00fEdCBafEdcbafEDCbAFedCBAFeDCbafEdCBAfeDcbaFeDCbAfEDCbAfeDcbAFE",
+            ),
+        )
+    }
 
     @Test
     fun `calculateAddressFromHash without deployer address`() {
@@ -35,5 +65,67 @@ internal class ContractAddressCalculatorTest {
         val expected = BigInteger("3179899882984850239687045389724311807765146621017486664543269641150383510696").toFelt
 
         assertEquals(expected, address)
+    }
+
+    @ParameterizedTest
+    @MethodSource("checksumAddresses")
+    fun `calculateChecksumAddress returns proper addresses`(case: ChecksumTestCase) {
+        assertEquals(
+            case.correct,
+            ContractAddressCalculator.calculateChecksumAddress(Felt.fromHex(case.incorrect)),
+        )
+        assertEquals(
+            case.correct,
+            ContractAddressCalculator.calculateChecksumAddress(Felt.fromHex(case.correct)),
+        )
+    }
+
+    @ParameterizedTest
+    @MethodSource("checksumAddresses")
+    fun `isChecksumAddressValid works`(case: ChecksumTestCase) {
+        assertTrue(ContractAddressCalculator.isChecksumAddressValid(case.correct))
+        assertFalse(ContractAddressCalculator.isChecksumAddressValid(case.incorrect))
+    }
+
+    fun byteArrayToHex(a: ByteArray): String {
+        val sb = StringBuilder(a.size * 2)
+        for (b in a) sb.append(String.format("%02x", b))
+        return sb.toString()
+    }
+
+    @Test
+    fun kck() {
+//        assertEquals(
+//            "0x5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2",
+//            keccak(byteArrayOf(1)).toHex(),
+//        )
+//        val list = mutableListOf<Byte>()
+//        list.addAll(
+//            HexFormat.of().parseHex("0x00abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefab")
+//        )
+        val byteArray = BigInteger("abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefab", 16).toByteArray()
+        println("HEX STRING")
+        println(Felt.fromHex("0xabcdefabcdefab").hexString())
+//        val byteArray = HexFormat.of().parseHex("abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefab")
+
+//        list.add(0.toByte())
+        assertEquals(32, byteArray.size)
+        println(byteArray[0])
+        println(BigInteger("abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefab", 16))
+//        assertEquals(
+//            "0xd5b179671f1663119ae493ffd1c621cba08fb301ae370dd5c828192d293a35f3",
+//            keccak(
+//                list.toByteArray(),
+//            ).toHex(),
+//        )
+
+        val keccak = Keccak.Digest256().apply {
+            update(byteArray)
+        }
+        val keccakResult = keccak.digest()
+        assertEquals(
+            "d5b179671f1663119ae493ffd1c621cba08fb301ae370dd5c828192d293a35f3",
+            byteArrayToHex(keccakResult),
+        )
     }
 }

--- a/lib/src/test/kotlin/com/swmansion/starknet/data/ContractAddressCalculatorTest.kt
+++ b/lib/src/test/kotlin/com/swmansion/starknet/data/ContractAddressCalculatorTest.kt
@@ -1,9 +1,7 @@
 package com.swmansion.starknet.data
 
-import com.swmansion.starknet.crypto.keccak
 import com.swmansion.starknet.data.types.Felt
 import com.swmansion.starknet.extensions.toFelt
-import org.bouncycastle.jcajce.provider.digest.Keccak
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -24,6 +22,7 @@ internal class ContractAddressCalculatorTest {
 
     companion object {
         // List of (address, valid checksum address)
+        // Correct values generated with starknet.js
         @JvmStatic
         fun checksumAddresses() = listOf(
             ChecksumTestCase(
@@ -37,6 +36,14 @@ internal class ContractAddressCalculatorTest {
             ChecksumTestCase(
                 "0xfedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcbafe",
                 "0x00fEdCBafEdcbafEDCbAFedCBAFeDCbafEdCBAfeDcbaFeDCbAfEDCbAfeDcbAFE",
+            ),
+            ChecksumTestCase(
+                "0xa",
+                "0x000000000000000000000000000000000000000000000000000000000000000A",
+            ),
+            ChecksumTestCase(
+                "0x0",
+                "0x0000000000000000000000000000000000000000000000000000000000000000",
             ),
         )
     }
@@ -85,47 +92,5 @@ internal class ContractAddressCalculatorTest {
     fun `isChecksumAddressValid works`(case: ChecksumTestCase) {
         assertTrue(ContractAddressCalculator.isChecksumAddressValid(case.correct))
         assertFalse(ContractAddressCalculator.isChecksumAddressValid(case.incorrect))
-    }
-
-    fun byteArrayToHex(a: ByteArray): String {
-        val sb = StringBuilder(a.size * 2)
-        for (b in a) sb.append(String.format("%02x", b))
-        return sb.toString()
-    }
-
-    @Test
-    fun kck() {
-//        assertEquals(
-//            "0x5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2",
-//            keccak(byteArrayOf(1)).toHex(),
-//        )
-//        val list = mutableListOf<Byte>()
-//        list.addAll(
-//            HexFormat.of().parseHex("0x00abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefab")
-//        )
-        val byteArray = BigInteger("abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefab", 16).toByteArray()
-        println("HEX STRING")
-        println(Felt.fromHex("0xabcdefabcdefab").hexString())
-//        val byteArray = HexFormat.of().parseHex("abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefab")
-
-//        list.add(0.toByte())
-        assertEquals(32, byteArray.size)
-        println(byteArray[0])
-        println(BigInteger("abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefab", 16))
-//        assertEquals(
-//            "0xd5b179671f1663119ae493ffd1c621cba08fb301ae370dd5c828192d293a35f3",
-//            keccak(
-//                list.toByteArray(),
-//            ).toHex(),
-//        )
-
-        val keccak = Keccak.Digest256().apply {
-            update(byteArray)
-        }
-        val keccakResult = keccak.digest()
-        assertEquals(
-            "d5b179671f1663119ae493ffd1c621cba08fb301ae370dd5c828192d293a35f3",
-            byteArrayToHex(keccakResult),
-        )
     }
 }

--- a/lib/src/test/kotlin/com/swmansion/starknet/extensions/BigIntegerKtTest.kt
+++ b/lib/src/test/kotlin/com/swmansion/starknet/extensions/BigIntegerKtTest.kt
@@ -1,0 +1,35 @@
+package com.swmansion.starknet.extensions
+
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.math.BigInteger
+
+internal class BigIntegerKtTest {
+    @Test
+    fun `toBytes should fail for negative number`() {
+        assertThrows<IllegalArgumentException>("Creating ByteArray from negative numbers is not supported.") {
+            BigInteger.valueOf(-1).toBytes()
+        }
+    }
+
+    @Test
+    fun `toBytes works on 0`() {
+        val result = BigInteger.valueOf(0).toBytes()
+        assertArrayEquals(ByteArray(1) { 0.toByte() }, result)
+    }
+
+    @Test
+    fun `toBytes doesn't cut first byte when it is not required`() {
+        val value = BigInteger.ONE
+        assertArrayEquals(value.toByteArray(), value.toBytes())
+    }
+
+    @Test
+    fun `toBytes removes first byte when bit length = 8n`() {
+        // bit length is 16 here, toByteArray would return [0, 0xff]
+        // as it adds one bit for the sign
+        val value = BigInteger("ff", 16)
+        assertArrayEquals(ByteArray(1) { 255.toByte() }, value.toBytes())
+    }
+}

--- a/lib/src/test/kotlin/com/swmansion/starknet/extensions/BigIntegerKtTest.kt
+++ b/lib/src/test/kotlin/com/swmansion/starknet/extensions/BigIntegerKtTest.kt
@@ -16,7 +16,7 @@ internal class BigIntegerKtTest {
     @Test
     fun `toBytes works on 0`() {
         val result = BigInteger.valueOf(0).toBytes()
-        assertArrayEquals(ByteArray(1) { 0.toByte() }, result)
+        assertArrayEquals(byteArrayOf(0), result)
     }
 
     @Test
@@ -30,6 +30,6 @@ internal class BigIntegerKtTest {
         // bit length is 16 here, toByteArray would return [0, 0xff]
         // as it adds one bit for the sign
         val value = BigInteger("ff", 16)
-        assertArrayEquals(ByteArray(1) { 255.toByte() }, value.toBytes())
+        assertArrayEquals(byteArrayOf(255.toByte()), value.toBytes())
     }
 }


### PR DESCRIPTION
## Describe your changes

Added methods for checksum addresses.

## Linked issues

Closes https://github.com/software-mansion/starknet-jvm/issues/182

## Breaking changes

- [x] This issue contains breaking changes

Our keccak used a mask right away. This might be misleading for users. I decided to follow starknet.js and rename it to `starknetKeccak`. Return types are different, so there shouldn't be any mistakes in using the wrong one.
