### PR TITLE
`ConvertibleToFeltList` interface

### DIFF
--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/Execution.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/Execution.kt
@@ -3,12 +3,14 @@
 package com.swmansion.starknet.data.types
 
 import com.swmansion.starknet.data.selectorFromName
+import com.swmansion.starknet.data.types.conversions.ConvertibleToCalldata
 import com.swmansion.starknet.data.types.transactions.InvokeTransaction
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 typealias Calldata = List<Felt>
 typealias Signature = List<Felt>
+typealias CallArguments = List<ConvertibleToCalldata>
 
 @Serializable
 data class Call(

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/Execution.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/Execution.kt
@@ -40,6 +40,19 @@ data class Call(
         entrypoint,
         emptyList(),
     )
+
+    companion object {
+        @JvmStatic
+        fun fromCallArguments(contractAddress: Felt, entrypoint: Felt, arguments: CallArguments): Call {
+            val calldata = arguments.flatMap { it.toCalldata() }
+            return Call(contractAddress, entrypoint, calldata)
+        }
+
+        @JvmStatic
+        fun fromCallArguments(contractAddress: Felt, entrypoint: String, arguments: CallArguments): Call {
+            return fromCallArguments(contractAddress, selectorFromName(entrypoint), arguments)
+        }
+    }
 }
 
 data class ExecutionParams(

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/Felt.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/Felt.kt
@@ -1,7 +1,7 @@
 package com.swmansion.starknet.data.types
 
 import com.swmansion.starknet.data.parseHex
-import com.swmansion.starknet.extensions.*
+import com.swmansion.starknet.data.types.conversions.ConvertibleToCalldata
 import com.swmansion.starknet.extensions.toHex
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
@@ -13,7 +13,7 @@ import kotlinx.serialization.encoding.Encoder
 import java.math.BigInteger
 
 @Serializable(with = FeltSerializer::class)
-data class Felt(val value: BigInteger) : Comparable<Felt> {
+data class Felt(val value: BigInteger) : Comparable<Felt>, ConvertibleToCalldata {
     constructor(value: Long) : this(BigInteger.valueOf(value))
     constructor(value: Int) : this(BigInteger.valueOf(value.toLong()))
 
@@ -29,6 +29,8 @@ data class Felt(val value: BigInteger) : Comparable<Felt> {
     override fun compareTo(other: Felt): Int {
         return value.compareTo(other.value)
     }
+
+    override fun toCalldata(): List<Felt> = listOf(this)
 
     override fun toString(): String {
         return "Felt(${value.toHex()})"

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/Uint256.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/Uint256.kt
@@ -1,13 +1,14 @@
 package com.swmansion.starknet.data.types
 
 import com.swmansion.starknet.data.parseHex
+import com.swmansion.starknet.data.types.conversions.ConvertibleToCalldata
 import java.math.BigInteger
 
 private val MAX: BigInteger = BigInteger.valueOf(2).pow(256).minus(BigInteger.ONE)
 private val SHIFT = 128
 private val SHIFT_MOD: BigInteger = BigInteger.valueOf(2).pow(128)
 
-data class Uint256(val value: BigInteger) {
+data class Uint256(val value: BigInteger) : ConvertibleToCalldata {
     constructor(value: Long) : this(BigInteger.valueOf(value))
     constructor(value: Int) : this(BigInteger.valueOf(value.toLong()))
     constructor(value: Felt) : this(value.value)
@@ -23,11 +24,23 @@ data class Uint256(val value: BigInteger) {
         }
     }
 
+    /**
+     * Get low 128 bits of Uint256
+     */
+    @Suppress("MemberVisibilityCanBePrivate")
     val low: Felt
         get() = Felt(value.mod(SHIFT_MOD))
 
+    /**
+     * Get high 128 bits of Uint256
+     */
+    @Suppress("MemberVisibilityCanBePrivate")
     val high: Felt
         get() = Felt(value.shiftRight(SHIFT))
+
+    override fun toCalldata(): List<Felt> {
+        return listOf(low, high)
+    }
 
     companion object {
         @field:JvmField

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/Uint256.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/Uint256.kt
@@ -4,8 +4,8 @@ import com.swmansion.starknet.data.parseHex
 import com.swmansion.starknet.data.types.conversions.ConvertibleToCalldata
 import java.math.BigInteger
 
+private const val SHIFT = 128
 private val MAX: BigInteger = BigInteger.valueOf(2).pow(256).minus(BigInteger.ONE)
-private val SHIFT = 128
 private val SHIFT_MOD: BigInteger = BigInteger.valueOf(2).pow(128)
 
 data class Uint256(val value: BigInteger) : ConvertibleToCalldata {
@@ -17,10 +17,10 @@ data class Uint256(val value: BigInteger) : ConvertibleToCalldata {
 
     init {
         if (value < BigInteger.ZERO) {
-            throw java.lang.IllegalArgumentException("Default Uint256 constructor does not accept negative numbers, [$value] given.")
+            throw IllegalArgumentException("Default Uint256 constructor does not accept negative numbers, [$value] given.")
         }
         if (value > MAX) {
-            throw java.lang.IllegalArgumentException("Default Uint256 constructor does not accept numbers higher than 2^256-1, [$value] given.")
+            throw IllegalArgumentException("Default Uint256 constructor does not accept numbers higher than 2^256-1, [$value] given.")
         }
     }
 

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/conversions/ConvertibleToCalldata.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/conversions/ConvertibleToCalldata.kt
@@ -1,0 +1,14 @@
+package com.swmansion.starknet.data.types.conversions
+
+import com.swmansion.starknet.data.types.Felt
+
+/**
+ * Implementers of this interface support conversions to
+ * the list of Felts.
+ */
+interface ConvertibleToCalldata {
+    /**
+     * @return this object as a list of Felts
+     */
+    fun toCalldata(): List<Felt>
+}

--- a/lib/src/test/kotlin/com/swmansion/starknet/data/CallTest.kt
+++ b/lib/src/test/kotlin/com/swmansion/starknet/data/CallTest.kt
@@ -1,0 +1,62 @@
+package com.swmansion.starknet.data
+
+import com.swmansion.starknet.data.types.Call
+import com.swmansion.starknet.data.types.Felt
+import com.swmansion.starknet.data.types.Uint256
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class CallTest {
+
+    private val address = Felt.fromHex("0x111")
+    private val selectorString = "abcdef"
+    private val selector = selectorFromName(selectorString)
+    private val param = Uint256.fromHex("0x210439592369239639725932969795495939596")
+    private val low = param.low
+    private val high = param.high
+    private val calldata = listOf(low, high)
+
+    private val expectedCall = Call(address, selector, calldata)
+
+    @Test
+    fun `create call from primary constructor`() {
+        val call = Call(address, selector, listOf(low, high))
+
+        assertEquals(expectedCall, call)
+    }
+
+    @Test
+    fun `create call from string entrypoint`() {
+        val call = Call(address, selectorString, listOf(low, high))
+
+        assertEquals(expectedCall, call)
+    }
+
+    @Test
+    fun `create call without calldata`() {
+        val call = Call(address, selector)
+
+        assertEquals(expectedCall.copy(calldata = emptyList()), call)
+    }
+
+    @Test
+    fun `create call without calldata string entrypoint`() {
+        val call = Call(address, selectorString)
+
+        assertEquals(expectedCall.copy(calldata = emptyList()), call)
+    }
+
+    @Test
+    fun `create call from call arguments`() {
+        val call = Call.fromCallArguments(address, selector, listOf(param))
+
+        assertEquals(expectedCall, call)
+    }
+
+    @Test
+    fun `create call from call arguments string entrypoint`() {
+        val call = Call.fromCallArguments(address, selectorString, listOf(param))
+
+        assertEquals(expectedCall, call)
+    }
+}

--- a/lib/src/test/kotlin/com/swmansion/starknet/data/Uint256Test.kt
+++ b/lib/src/test/kotlin/com/swmansion/starknet/data/Uint256Test.kt
@@ -1,0 +1,93 @@
+package com.swmansion.starknet.data
+
+import com.swmansion.starknet.data.types.Felt
+import com.swmansion.starknet.data.types.Uint256
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.math.BigInteger
+
+internal class Uint256Test {
+    private val bigIntegerValue = BigInteger("115792089237316195423570985008687907853269984665640564039457584007913129639935")
+
+    @Test
+    fun `construct uint256 from BigInteger`() {
+        val uint256 = Uint256(bigIntegerValue)
+
+        assertEquals(uint256.value, bigIntegerValue)
+    }
+
+    @Test
+    fun `construct uint256 from high and low felt`() {
+        val uint256 = Uint256(bigIntegerValue)
+        val low = uint256.low
+        val high = uint256.high
+
+        assertEquals(uint256, Uint256(low, high))
+    }
+
+    @Test
+    fun `construct uint256 from high and low`() {
+        val uint256 = Uint256(bigIntegerValue)
+        val low = BigInteger(uint256.low.decString())
+        val high = BigInteger(uint256.high.decString())
+
+        assertEquals(uint256, Uint256(low, high))
+    }
+
+    @Test
+    fun `construct uint256 from int`() {
+        val uint256 = Uint256(23)
+
+        assertEquals(uint256.low.decString(), "23")
+        assertEquals(uint256.high.decString(), "0")
+    }
+
+    @Test
+    fun `construct uint256 from long`() {
+        val uint256 = Uint256(9223372036854775807L)
+
+        assertEquals(uint256.low.decString(), "9223372036854775807")
+        assertEquals(uint256.high.decString(), "0")
+    }
+
+    @Test
+    fun `construct uint256 from felt`() {
+        val uint256 = Uint256(Felt(4215215))
+
+        assertEquals(uint256.low.decString(), "4215215")
+        assertEquals(uint256.high.decString(), "0")
+    }
+
+    @Test
+    fun `uint256 from hex string`() {
+        val low = Felt.fromHex("0x92369239639725932969795495939596")
+        val high = Felt.fromHex("0x2104395")
+        val uint256 = Uint256.fromHex("0x210439592369239639725932969795495939596")
+
+        assertEquals(uint256, Uint256(low, high))
+    }
+
+    @Test
+    fun `construct uint256 below 0`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            Uint256(BigInteger("-1"))
+        }
+    }
+
+    @Test
+    fun `construct uint256 above max`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            Uint256(BigInteger.valueOf(2).pow(256))
+        }
+    }
+
+    @Test
+    fun `convert uint256 to felt list`() {
+        val uint256 = Uint256.fromHex("0x210439592369239639725932969795495939596")
+        val low = Felt.fromHex("0x92369239639725932969795495939596")
+        val high = Felt.fromHex("0x2104395")
+
+        val feltList = uint256.toCalldata()
+        assertEquals(listOf(low, high), feltList)
+    }
+}


### PR DESCRIPTION
## Describe your changes

<!-- A brief description of the changes introduced in this PR -->

This PR introduces `ConvertibleToFeltList` interface to indicate that an object can be converted to list of Felts, e.g. to be used as Calldata.

It makes Uint256 implement ConvertibleToFeltList.

It makes StarkCurveSignature implement ConvertibleToFeltList.

It also does some cleanup of Uint256 class and introduces Uint256 tests.

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #188 

## Breaking changes

- [x] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->

* StarkCurveSignature `toList()` method replaced with `toFeltList()`.


