### PR TITLE
Add docs about `ConvertibleToCalldata`

### DIFF
--- a/javademo/src/main/java/com/example/javademo/Main.java
+++ b/javademo/src/main/java/com/example/javademo/Main.java
@@ -37,9 +37,17 @@ public class Main {
         Request<DeployResponse> deployRequest = provider.deployContract(payload);
         DeployResponse deployResponse = deployRequest.send();
 
-        // Invoke a contract
+        // Create a call from plain calldata
         Felt contractAddress = deployResponse.getContractAddress();
         Call call = new Call(contractAddress, "increaseBalance", List.of(new Felt(1000)));
+        // Or using any objects implementing ConvertibleToCalldata
+        Call callFromCallArguments = Call.fromCallArguments(
+                contractAddress,
+                "increaseBalance",
+                List.of(Uint256.fromHex("0x9148582852675472"), new Felt(1000))
+        );
+
+        // Invoke a contract
         Request<InvokeFunctionResponse> executeRequest = account.execute(call);
         InvokeFunctionResponse executeResponse = executeRequest.send();
 

--- a/javademo/src/main/java/com/example/javademo/Main.java
+++ b/javademo/src/main/java/com/example/javademo/Main.java
@@ -22,7 +22,7 @@ public class Main {
         // Set up an account
         Felt address = Felt.fromHex("0x1234");
         // ⚠️ WARNING ⚠️ The key generated here is just for demonstration purposes.
-        // DO NOT GENERATE YOUR KEYS THIS WAY. USE CRYPTOGRA️FICALLY SAFE TOOLS!
+        // DO NOT GENERATE YOUR KEYS THIS WAY. USE CRYPTOGRAPHICALLY SAFE TOOLS!
         Felt privateKey = new Felt(ThreadLocalRandom.current().nextLong(1, Long.MAX_VALUE));
         Provider provider = GatewayProvider.makeTestnetClient();
         Account account = new StandardAccount(address, privateKey, provider);
@@ -33,14 +33,18 @@ public class Main {
 
         // Deploy a contract
         ContractDefinition contractDefinition = new ContractDefinition(contract);
-        DeployTransactionPayload payload = new DeployTransactionPayload(contractDefinition, Felt.fromHex("0x1234"), Collections.emptyList(), Felt.ZERO);
+        DeployTransactionPayload payload = new DeployTransactionPayload(
+                contractDefinition,
+                Felt.fromHex("0x1234"),
+                Collections.emptyList(), Felt.ZERO
+        );
         Request<DeployResponse> deployRequest = provider.deployContract(payload);
         DeployResponse deployResponse = deployRequest.send();
 
         // Create a call from plain calldata
         Felt contractAddress = deployResponse.getContractAddress();
         Call call = new Call(contractAddress, "increaseBalance", List.of(new Felt(1000)));
-        // Or using any objects implementing ConvertibleToCalldata
+        // Or using any objects implementing ConvertibleToCalldata interface
         Call callFromCallArguments = Call.fromCallArguments(
                 contractAddress,
                 "increaseBalance",
@@ -54,7 +58,7 @@ public class Main {
         // Make sure that the transaction succeeded
         Request<? extends TransactionReceipt> receiptRequest = provider.getTransactionReceipt(executeResponse.getTransactionHash());
         TransactionReceipt receipt = receiptRequest.send();
-        Boolean isAccepted = (receipt.getStatus() == TransactionStatus.ACCEPTED_ON_L2) || (receipt.getStatus() == TransactionStatus.ACCEPTED_ON_L1);
+        Boolean isAccepted = receipt.isAccepted();
 
         // Manually sign a hash
         Felt hash = Felt.fromHex("0x121212121212");

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/Execution.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/Execution.kt
@@ -41,12 +41,49 @@ data class Call(
     )
 
     companion object {
+        /**
+         * Construct a Call object using any objects conforming to ConvertibleToCalldata as calldata
+         * instead of plain Felts.
+         *
+         * For example:
+         * ```
+         * Call.fromCallArguments(
+         *      Felt.fromHex("0x1234"),
+         *      Felt.fromHex("0x111"),
+         *      Collections.listOf(Uint256.fromHex("0x1394924"), Felt.ZERO)
+         * );
+         * ```
+         *
+         * @param contractAddress an address to be called
+         * @param entrypoint a selector of the entrypoint to be called
+         * @param arguments CallArguments to be used in a call
+         *
+         * @return a Call object
+         */
         @JvmStatic
         fun fromCallArguments(contractAddress: Felt, entrypoint: Felt, arguments: CallArguments): Call {
             val calldata = arguments.flatMap { it.toCalldata() }
             return Call(contractAddress, entrypoint, calldata)
         }
 
+        /**
+         * Construct a Call object using any objects conforming to ConvertibleToCalldata as calldata
+         * instead of plain Felts, using selector name.
+         *
+         * For example:
+         * ```
+         * Call.fromCallArguments(
+         *      Felt.fromHex("0x1234"),
+         *      "mySelector",
+         *      Collections.listOf(Uint256.fromHex("0x1394924"), Felt.ZERO)
+         * );
+         *
+         * @param contractAddress an address to be called
+         * @param entrypoint a name of the entrypoint to be called
+         * @param arguments CallArguments to be used in a call
+         *
+         * @return a Call object
+         */
         @JvmStatic
         fun fromCallArguments(contractAddress: Felt, entrypoint: String, arguments: CallArguments): Call {
             return fromCallArguments(contractAddress, selectorFromName(entrypoint), arguments)


### PR DESCRIPTION
## Describe your changes

<!-- A brief description of the changes introduced in this PR -->

This PR improves doc comments in `Call` class and extends javademo to show usages of `Call.fromCallArguments`.

This PR also introduces a bit of cleanup and reformatting in javademo.

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #201 

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
