### PR TITLE
Rollback ubuntu version for x64 builds

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -19,7 +19,7 @@ jobs:
     needs: [verify_version]
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-20.04, macos-latest ]
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
## Describe your changes

Actions fail to build because of recent ubuntu version bump https://github.com/software-mansion/starknet-jvm/actions/runs/3648453295/jobs/6162840367

This rolls back the change and fixes system version.
This is a workaround.

## Linked issues

Closes

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
