### PR TITLE
Extend documentation

### DIFF
--- a/lib/src/main/kotlin/com/swmansion/starknet/provider/Request.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/provider/Request.kt
@@ -1,6 +1,8 @@
 package com.swmansion.starknet.provider
 
+import com.swmansion.starknet.provider.exceptions.RequestFailedException
 import java.util.concurrent.CompletableFuture
+import kotlin.jvm.Throws
 
 /**
  * An interface implemented by all return values of providers.
@@ -11,6 +13,7 @@ interface Request<T> {
      *
      * @return a result of the request
      */
+    @Throws(RequestFailedException::class)
     fun send(): T
 
     /**

--- a/lib/src/main/kotlin/com/swmansion/starknet/provider/gateway/GatewayProvider.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/provider/gateway/GatewayProvider.kt
@@ -436,7 +436,7 @@ class GatewayProvider(
 
     companion object Factory {
         @JvmStatic
-        fun makeTestnetClient(): GatewayProvider {
+        fun makeTestnetProvider(): GatewayProvider {
             return GatewayProvider(
                 "$TESTNET_URL/feeder_gateway",
                 "$TESTNET_URL/gateway",
@@ -445,7 +445,7 @@ class GatewayProvider(
         }
 
         @JvmStatic
-        fun makeTestnetClient(testnetId: StarknetChainId): GatewayProvider =
+        fun makeTestnetProvider(testnetId: StarknetChainId): GatewayProvider =
             when (testnetId) {
                 StarknetChainId.TESTNET -> GatewayProvider(
                     "$TESTNET_URL/feeder_gateway",
@@ -461,7 +461,7 @@ class GatewayProvider(
             }
 
         @JvmStatic
-        fun makeTestnetClient(httpService: HttpService): GatewayProvider {
+        fun makeTestnetProvider(httpService: HttpService): GatewayProvider {
             return GatewayProvider(
                 "$TESTNET_URL/feeder_gateway",
                 "$TESTNET_URL/gateway",
@@ -471,7 +471,7 @@ class GatewayProvider(
         }
 
         @JvmStatic
-        fun makeTestnetClient(testnetId: StarknetChainId, httpService: HttpService): GatewayProvider =
+        fun makeTestnetProvider(testnetId: StarknetChainId, httpService: HttpService): GatewayProvider =
             when (testnetId) {
                 StarknetChainId.TESTNET -> GatewayProvider(
                     "$TESTNET_URL/feeder_gateway",
@@ -489,7 +489,7 @@ class GatewayProvider(
             }
 
         @JvmStatic
-        fun makeMainnetClient(): GatewayProvider {
+        fun makeMainnetProvider(): GatewayProvider {
             return GatewayProvider(
                 "$MAINNET_URL/feeder_gateway",
                 "$MAINNET_URL/gateway",
@@ -498,7 +498,7 @@ class GatewayProvider(
         }
 
         @JvmStatic
-        fun makeMainnetClient(httpService: HttpService): GatewayProvider {
+        fun makeMainnetProvider(httpService: HttpService): GatewayProvider {
             return GatewayProvider(
                 "$MAINNET_URL/feeder_gateway",
                 "$MAINNET_URL/gateway",

--- a/lib/src/test/kotlin/starknet/provider/ProviderTest.kt
+++ b/lib/src/test/kotlin/starknet/provider/ProviderTest.kt
@@ -5,6 +5,7 @@ import com.swmansion.starknet.data.types.*
 import com.swmansion.starknet.data.types.transactions.*
 import com.swmansion.starknet.provider.Provider
 import com.swmansion.starknet.provider.exceptions.GatewayRequestFailedException
+import com.swmansion.starknet.provider.exceptions.RequestFailedException
 import com.swmansion.starknet.provider.exceptions.RpcRequestFailedException
 import com.swmansion.starknet.provider.gateway.GatewayProvider
 import com.swmansion.starknet.provider.rpc.JsonRpcProvider
@@ -158,6 +159,21 @@ class ProviderTest {
         val balance = response.first()
 
         assertEquals(expected, balance)
+    }
+
+    @ParameterizedTest
+    @MethodSource("getProviders")
+    fun `call contract with incorrect address throws`(provider: Provider) {
+        val call = Call(
+            Felt.ZERO,
+            "get_balance",
+            emptyList(),
+        )
+        val request = provider.callContract(call, BlockTag.LATEST)
+
+        assertThrows(RequestFailedException::class.java) {
+            request.send()
+        }
     }
 
     @ParameterizedTest

--- a/lib/src/test/kotlin/starknet/provider/ProviderTest.kt
+++ b/lib/src/test/kotlin/starknet/provider/ProviderTest.kt
@@ -813,7 +813,7 @@ class ProviderTest {
                 """.trimIndent(),
             )
         }
-        val provider = GatewayProvider.makeTestnetClient(httpService)
+        val provider = GatewayProvider.makeTestnetProvider(httpService)
         val receipt = provider.getTransactionReceipt(hash).send() as GatewayTransactionReceipt
 
         assertEquals(hash, receipt.hash)

--- a/lib/starknet-jvm.md
+++ b/lib/starknet-jvm.md
@@ -21,7 +21,7 @@ import com.swmansion.starknet.provider.gateway.GatewayProvider;
 public class Main {
     public static void main(String[] args) {
         // Create a provider for interacting with StarkNet
-        Provider provider = GatewayProvider.makeTestnetClient();
+        Provider provider = GatewayProvider.makeTestnetProvider();
 
         // Create an account interface
         Felt accountAddress = Felt.fromHex("0x13241455");
@@ -49,7 +49,7 @@ import com.swmansion.starknet.provider.gateway.GatewayProvider
 
 fun main() {
     // Create a provider for interacting with StarkNet
-    val provider = GatewayProvider.makeTestnetClient()
+    val provider = GatewayProvider.makeTestnetProvider()
 
     // Create an account interface
     val accountAddress = Felt.fromHex("0x1052524524")
@@ -87,7 +87,7 @@ import java.util.concurrent.CompletableFuture;
 public class Main {
     public static void main(String[] args) {
         // Create a provider for interacting with StarkNet
-        Provider provider = GatewayProvider.makeTestnetClient();
+        Provider provider = GatewayProvider.makeTestnetProvider();
 
         // Create an account interface
         Felt accountAddress = Felt.fromHex("0x13241455");
@@ -115,7 +115,7 @@ import com.swmansion.starknet.provider.gateway.GatewayProvider
 
 fun main() {
     // Create a provider for interacting with StarkNet
-    val provider = GatewayProvider.makeTestnetClient()
+    val provider = GatewayProvider.makeTestnetProvider()
 
     // Create an account interface
     val accountAddress = Felt.fromHex("0x1052524524")
@@ -151,7 +151,7 @@ import java.util.List;
 
 public class Main {
     public static void main(String[] args) {
-        Provider provider = GatewayProvider.makeTestnetClient();
+        Provider provider = GatewayProvider.makeTestnetProvider();
         Felt address = new Felt(0x1234);
         Felt privateKey = new Felt(0x1);
         Account account = new StandardAccount(provider, address, privateKey);
@@ -187,7 +187,7 @@ or in Kotlin
 
 ```kotlin
 fun main(args: Array<String>) {
-    val provider: Provider = makeTestnetClient()
+    val provider: Provider = makeTestnetProvider()
     val address = Felt(0x1234)
     val privateKey = Felt(0x1)
     val account: Account = StandardAccount(provider, address, privateKey)
@@ -220,7 +220,9 @@ fun main(args: Array<String>) {
 
 # Package com.swmansion.starknet.crypto
 
-Cryptography and signature related classes.
+The crypto module contains classes and functions for working with cryptography.
+These are lower level interfaces, we recommend using Account and Signer interfaces
+instead.
 
 # Package com.swmansion.starknet.data
 
@@ -228,28 +230,83 @@ Data classes representing StarkNet objects and utilities for handling them.
 
 # Package com.swmansion.starknet.data.types
 
-Data classes representing StarkNet objects.
+The types module contains classes representing various data types used in StarkNet and utilities for
+interacting with them.
 
 # Package com.swmansion.starknet.data.types.transactions
 
-Data classes representing StarkNet transactions.
+The transactions submodule of the types module contains classes representing sent and received transactions
+as well as payloads of transactions to be sent. 
 
 # Package com.swmansion.starknet.provider
 
-Provider interface used for interacting with StarkNet.
+The provider module contains the Provider interface and its implementations. 
+The Provider interface defines methods for interacting with StarkNet,
+such as calling contracts and querying the state of the network.
+
+```java
+// Create a provider instance
+Provider provider = ...
+
+// Get a storage value request
+Request<Felt> request = provider.getStorageAt(address, key);
+// Send a request
+Felt response = request.send();
+
+// For most methods block hash, number or tag can be specified
+Request<Felt> request = provider.getStorageAt(address, key, Felt.fromHex("0x123..."));
+Request<Felt> request = provider.getStorageAt(address, key, 1234);
+Request<Felt> request = provider.getStorageAt(address, key, BlockTag.LATEST);
+```
 
 # Package com.swmansion.starknet.provider.exceptions
 
 Exceptions thrown by the StarkNet providers.
 
+`Request.send()` throws `RequestFailedException` which has to be 
+handled when writing in Java.
+
+```java
+Request<Felt> request = ...
+// Send a request
+try {
+    Felt response = request.send();
+} catch (RequestFailedException e) {
+    // Handle an exception
+}
+```
+
+In the case of `Request.sendAsync()`, an exception would have to be handled in the returned `CompletableFuture`.
+
 # Package com.swmansion.starknet.provider.gateway
 
 Provider utilising StarkNet gateway and feeder gateway for communication with the network.
+
+```java
+// Create a provider using a factory
+GatewayProvider.makeTestnetProvider();
+// Chain id can be specified
+GatewayProvider.makeTestnetProvider(StarknetChainId.TESTNET2);
+// As well as the custom HttpService
+GatewayProvider.makeTestnetProvider(myHttpService, StarknetChainId.TESTNET2);
+
+// Provider can be also created using a construcotr
+new GatewayProvider("feederGatewayUrl", "gatewayUrl", StarknetChainId.TESTNET);
+// or with a custom HttpService
+new GatewayProvider("feederGatewayUrl", "gatewayUrl", StarknetChainId.TESTNET, myHttpService); 
+```
 
 # Package com.swmansion.starknet.provider.rpc
 
 Provider implementing the [JSON RPC interface](https://github.com/starkware-libs/starknet-specs)
 to communicate with the network.
+
+```java
+// JsonRpcProvider can only be created using constructor
+new JsonRpcProvider("rpcNodeUrl", StarknetChainId.TESTNET);
+// or with a custom HttpService
+new JsonRpcProvider("rpcNodeUrl", StarknetChainId.TESTNET, myHttpService);
+```
 
 # Package com.swmansion.starknet.service.http
 
@@ -263,14 +320,22 @@ import com.swmansion.starknet.service.http.OkHttpService;
 
 // (...)
 
-var httpClient = new OkHttpClient();
-var httpService = new OkHttpService(httpClient);
-
-var provider = GatewayProvider.makeTestnetClient(httpService);
-var account1 = new StandardAccount(provider, accountAddress1, privateKey1);
-var account2 = new StandardAccount(provider, accountAddress2, privateKey2);
+OkHttpClient httpClient = new OkHttpClient();
+OkHttpService httpService = new OkHttpService(httpClient);
 ```
 
 # Package com.swmansion.starknet.signer
 
-Signer interface used to sign StarkNet transactions.
+The signer module contains the Signer interface and its implementations. 
+Recommended way of using Signer is through an Account.
+
+```java
+// Create a signer
+Signer signer = ...
+        
+// Sign a transaction
+List<Felt> signature = signer.signTransaction(tx);
+
+// Get a public key
+Felt publicKey = signer.getPublicKey();
+```


### PR DESCRIPTION
## Describe your changes

<!-- A brief description of the changes introduced in this PR -->

- Extended package specific docs, added code examples
- Renamed `make_Client` to `make_Provider`
- Added `@Throws` annotation to `Request` interface, to make `RequestFailedException` a checked exception in Java  

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #98 

## Breaking changes

- [x] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->

- Renamed `make_Client` to `make_Provider`
