### PR TITLE
Support for older glibc for arm + update actions

### DIFF
--- a/.github/workflows/Dockerfile.multiarch
+++ b/.github/workflows/Dockerfile.multiarch
@@ -4,9 +4,12 @@ RUN curl https://apt.corretto.aws/corretto.key > corretto.key \
     && apt-key add corretto.key \
     && add-apt-repository 'deb https://apt.corretto.aws stable main' \
     && apt update \
-    && apt install -y cmake clang java-11-amazon-corretto-jdk \
+    && apt install -y cmake clang java-11-amazon-corretto-jdk g++-7 \
+    && find /usr/lib/gcc/x86_64-linux-gnu/ -maxdepth 1 -mindepth 1 ! -name 7 -delete \
     && mkdir /build
 ENV JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto
+ENV CC=/usr/bin/gcc-7
+ENV CXX=/usr/bin/g++-7
 COPY . /build/.
 WORKDIR /build/lib
 RUN ./build_crypto_cpp.sh

--- a/.github/workflows/Dockerfile.multiarch
+++ b/.github/workflows/Dockerfile.multiarch
@@ -5,7 +5,7 @@ RUN curl https://apt.corretto.aws/corretto.key > corretto.key \
     && add-apt-repository 'deb https://apt.corretto.aws stable main' \
     && apt update \
     && apt install -y cmake clang java-11-amazon-corretto-jdk g++-7 \
-    && find /usr/lib/gcc/x86_64-linux-gnu/ -maxdepth 1 -mindepth 1 ! -name 7 -exec rm -rf {} + \
+    && find /usr/lib/gcc/x86_64-linux-gnu/ -maxdepth 1 -mindepth 1 ! -name 7 -exec rm -rf {} + || true \
     && mkdir /build
 ENV JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto
 ENV CC=/usr/bin/gcc-7

--- a/.github/workflows/Dockerfile.multiarch
+++ b/.github/workflows/Dockerfile.multiarch
@@ -5,7 +5,7 @@ RUN curl https://apt.corretto.aws/corretto.key > corretto.key \
     && add-apt-repository 'deb https://apt.corretto.aws stable main' \
     && apt update \
     && apt install -y cmake clang java-11-amazon-corretto-jdk g++-7 \
-    && find /usr/lib/gcc/x86_64-linux-gnu/ -maxdepth 1 -mindepth 1 ! -name 7 -exec rm -rf {} + || true \
+    && find /usr/lib/gcc/aarch64-linux-gnu/ -maxdepth 1 -mindepth 1 ! -name 7 -exec rm -rf {} + \
     && mkdir /build
 ENV JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto
 ENV CC=/usr/bin/gcc-7

--- a/.github/workflows/Dockerfile.multiarch
+++ b/.github/workflows/Dockerfile.multiarch
@@ -5,7 +5,7 @@ RUN curl https://apt.corretto.aws/corretto.key > corretto.key \
     && add-apt-repository 'deb https://apt.corretto.aws stable main' \
     && apt update \
     && apt install -y cmake clang java-11-amazon-corretto-jdk g++-7 \
-    && find /usr/lib/gcc/x86_64-linux-gnu/ -maxdepth 1 -mindepth 1 ! -name 7 -delete \
+    && find /usr/lib/gcc/x86_64-linux-gnu/ -maxdepth 1 -mindepth 1 ! -name 7 -exec rm -rf {} + \
     && mkdir /build
 ENV JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto
 ENV CC=/usr/bin/gcc-7

--- a/.github/workflows/Dockerfile.multiarch
+++ b/.github/workflows/Dockerfile.multiarch
@@ -5,6 +5,8 @@ RUN curl https://apt.corretto.aws/corretto.key > corretto.key \
     && add-apt-repository 'deb https://apt.corretto.aws stable main' \
     && apt update \
     && apt install -y cmake clang java-11-amazon-corretto-jdk g++-7 \
+    # Inside the /usr/lib/gcc/aarch64-linux-gnu/ find all the directories that aren't named '7'
+    # And then remove them recursively, to force the usage of gcc-7
     && find /usr/lib/gcc/aarch64-linux-gnu/ -maxdepth 1 -mindepth 1 ! -name 7 -exec rm -rf {} + \
     && mkdir /build
 ENV JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto

--- a/.github/workflows/build-and-publish-docs.yml
+++ b/.github/workflows/build-and-publish-docs.yml
@@ -32,7 +32,7 @@ jobs:
           cp -R lib/build/dokka/html lib/build/dokka/javadoc/kotlin/
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: JamesIves/github-pages-deploy-action@66b02ca51987e10cad29b320023d7c39eff2d4ca
         with:
           folder: lib/build/dokka/javadoc
           branch: gh-pages

--- a/.github/workflows/build-and-publish-docs.yml
+++ b/.github/workflows/build-and-publish-docs.yml
@@ -31,9 +31,9 @@ jobs:
           ./gradlew :lib:dokkaHtml
           cp -R lib/build/dokka/html lib/build/dokka/javadoc/kotlin/
 
-      - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@66b02ca51987e10cad29b320023d7c39eff2d4ca
-        with:
-          folder: lib/build/dokka/javadoc
-          branch: gh-pages
-          single-commit: true
+      # - name: Deploy
+      #   uses: JamesIves/github-pages-deploy-action@66b02ca51987e10cad29b320023d7c39eff2d4ca
+      #   with:
+      #     folder: lib/build/dokka/javadoc
+      #     branch: gh-pages
+      #     single-commit: true

--- a/.github/workflows/build-and-publish-docs.yml
+++ b/.github/workflows/build-and-publish-docs.yml
@@ -31,9 +31,9 @@ jobs:
           ./gradlew :lib:dokkaHtml
           cp -R lib/build/dokka/html lib/build/dokka/javadoc/kotlin/
 
-      # - name: Deploy
-      #   uses: JamesIves/github-pages-deploy-action@66b02ca51987e10cad29b320023d7c39eff2d4ca
-      #   with:
-      #     folder: lib/build/dokka/javadoc
-      #     branch: gh-pages
-      #     single-commit: true
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@66b02ca51987e10cad29b320023d7c39eff2d4ca
+        with:
+          folder: lib/build/dokka/javadoc
+          branch: gh-pages
+          single-commit: true

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Force usage of gcc 7
         run: |
           # First delete any version other than 7
-          sudo find /usr/lib/gcc/x86_64-linux-gnu/ -maxdepth 1 -mindepth 1 ! -name 7 -delete
+          sudo find /usr/lib/gcc/x86_64-linux-gnu/ -maxdepth 1 -mindepth 1 ! -name 7 -exec rm -rf {} +
           echo "CC=/usr/bin/gcc-7" >> $GITHUB_ENV
           echo "CXX=/usr/bin/g++-7" >> $GITHUB_ENV
         shell: bash

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -2,10 +2,8 @@ name: Build And Publish Packages
 
 on:
   push:
-    # tags:
-    #   - '*'
-    branches:
-      - szymczyk/189_171-update_actions
+    tags:
+      - '*'
 
 jobs:
   verify_version:
@@ -15,7 +13,7 @@ jobs:
       - name: Verify correct version
         run: |
           [ $(grep -e "version = " lib/build.gradle.kts | awk -F'"' '{print $2}') == "$GITHUB_REF_NAME" ] \
-          || { echo "Mismatch between tag and lib version set in gradle build file, cannot continue."; } # exit 1; }
+          || { echo "Mismatch between tag and lib version set in gradle build file, cannot continue."; exit 1; }
   build_x64:
     runs-on: ${{ matrix.os }}
     needs: [verify_version]
@@ -163,32 +161,32 @@ jobs:
           name: sources-jar
           path: sources.jar
 
-  # publish:
-  #   runs-on: ubuntu-20.04
-  #   needs: [package_jar, generate_javadoc_and_sources]
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: actions/download-artifact@v3
-  #       with:
-  #         path: lib/
-  #     - name: Set up Java
-  #       uses: actions/setup-java@v3
-  #       with:
-  #         java-version: 11
-  #         distribution: 'corretto'
-  #     - name: Publish package
-  #       uses: gradle/gradle-build-action@v2
-  #       with:
-  #         arguments: publish closeAndReleaseRepository
-  #       env:
-  #         MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-  #         MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-  #         ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_signingKey }}
-  #         ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_signingPassword }}
-  #     - uses: softprops/action-gh-release@d4e8205d7e959a9107da6396278b2f1f07af0f9b
-  #       with:
-  #         files: |
-  #           lib/javadoc-jar/*.jar
-  #           lib/sources-jar/*.jar
-  #           lib/starknet-jar/*.jar
-  #           lib/starknet-aar/*.aar
+  publish:
+    runs-on: ubuntu-20.04
+    needs: [package_jar, generate_javadoc_and_sources]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          path: lib/
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'corretto'
+      - name: Publish package
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: publish closeAndReleaseRepository
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_signingKey }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_signingPassword }}
+      - uses: softprops/action-gh-release@d4e8205d7e959a9107da6396278b2f1f07af0f9b
+        with:
+          files: |
+            lib/javadoc-jar/*.jar
+            lib/sources-jar/*.jar
+            lib/starknet-jar/*.jar
+            lib/starknet-aar/*.aar

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -120,7 +120,7 @@ jobs:
     needs: [build_x64, build_virt]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           path: download
       - name: Move shared libs

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -2,8 +2,10 @@ name: Build And Publish Packages
 
 on:
   push:
-    tags:
-      - '*'
+    # tags:
+    #   - '*'
+    branches:
+      - szymczyk/189_171-update_actions
 
 jobs:
   verify_version:
@@ -13,7 +15,7 @@ jobs:
       - name: Verify correct version
         run: |
           [ $(grep -e "version = " lib/build.gradle.kts | awk -F'"' '{print $2}') == "$GITHUB_REF_NAME" ] \
-          || { echo "Mismatch between tag and lib version set in gradle build file, cannot continue."; exit 1; }
+          || { echo "Mismatch between tag and lib version set in gradle build file, cannot continue."; } # exit 1; }
   build_x64:
     runs-on: ${{ matrix.os }}
     needs: [verify_version]
@@ -161,32 +163,32 @@ jobs:
           name: sources-jar
           path: sources.jar
 
-  publish:
-    runs-on: ubuntu-20.04
-    needs: [package_jar, generate_javadoc_and_sources]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
-        with:
-          path: lib/
-      - name: Set up Java
-        uses: actions/setup-java@v3
-        with:
-          java-version: 11
-          distribution: 'corretto'
-      - name: Publish package
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: publish closeAndReleaseRepository
-        env:
-          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_signingKey }}
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_signingPassword }}
-      - uses: softprops/action-gh-release@d4e8205d7e959a9107da6396278b2f1f07af0f9b
-        with:
-          files: |
-            lib/javadoc-jar/*.jar
-            lib/sources-jar/*.jar
-            lib/starknet-jar/*.jar
-            lib/starknet-aar/*.aar
+  # publish:
+  #   runs-on: ubuntu-20.04
+  #   needs: [package_jar, generate_javadoc_and_sources]
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: actions/download-artifact@v3
+  #       with:
+  #         path: lib/
+  #     - name: Set up Java
+  #       uses: actions/setup-java@v3
+  #       with:
+  #         java-version: 11
+  #         distribution: 'corretto'
+  #     - name: Publish package
+  #       uses: gradle/gradle-build-action@v2
+  #       with:
+  #         arguments: publish closeAndReleaseRepository
+  #       env:
+  #         MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+  #         MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+  #         ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_signingKey }}
+  #         ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_signingPassword }}
+  #     - uses: softprops/action-gh-release@d4e8205d7e959a9107da6396278b2f1f07af0f9b
+  #       with:
+  #         files: |
+  #           lib/javadoc-jar/*.jar
+  #           lib/sources-jar/*.jar
+  #           lib/starknet-jar/*.jar
+  #           lib/starknet-aar/*.aar

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -39,7 +39,7 @@ jobs:
 
       # See https://github.com/software-mansion/starknet-jvm/issues/171
       - name: Set up GCC 7
-        run: apt update && apt install -y g++-7
+        run: sudo apt update && sudo apt install -y g++-7
         if: matrix.os == 'ubuntu-20.04'
       - name: Force usage of gcc 7
         run: |

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -9,7 +9,7 @@ jobs:
   verify_version:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Verify correct version
         run: |
           [ $(grep -e "version = " lib/build.gradle.kts | awk -F'"' '{print $2}') == "$GITHUB_REF_NAME" ] \
@@ -21,11 +21,11 @@ jobs:
       matrix:
         os: [ ubuntu-20.04, macos-latest ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.12
+        uses: jwlawson/actions-setup-cmake@4f73d30c2fc44a9466a3ed890fb8db7a7b554302
         with:
           cmake-version: '3.16.x'
       - name: Set up Java
@@ -37,17 +37,12 @@ jobs:
 
       # See https://github.com/software-mansion/starknet-jvm/issues/171
       - name: Set up GCC 7
-        uses: egor-tensin/setup-gcc@v1
-        with:
-          version: 7
-          platform: x64
+        run: apt update && apt install -y g++-7
         if: matrix.os == 'ubuntu-20.04'
       - name: Force usage of gcc 7
         run: |
           # First delete any version other than 7
-          sudo mv /usr/lib/gcc/x86_64-linux-gnu/7 /tmp/gcc7
-          sudo rm -r /usr/lib/gcc/x86_64-linux-gnu/* 
-          sudo mv /tmp/gcc7 /usr/lib/gcc/x86_64-linux-gnu/7
+          sudo find /usr/lib/gcc/x86_64-linux-gnu/ -maxdepth 1 -mindepth 1 ! -name 7 -delete
           echo "CC=/usr/bin/gcc-7" >> $GITHUB_ENV
           echo "CXX=/usr/bin/g++-7" >> $GITHUB_ENV
         shell: bash
@@ -55,12 +50,12 @@ jobs:
 
       - name: Set arch variable
         id: vars
-        run: echo "::set-output name=os_arch::$(uname -m)"
+        run: echo "os_arch=$(uname -m)" >> $GITHUB_OUTPUT
 
       - name: Build platform specific lib
         run: ./gradlew buildCryptoCpp
       - name: Upload the shared lib
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: lib-${{ runner.os }}-${{ steps.vars.outputs.os_arch }}
           path: crypto/build/bindings/libcrypto_jni.*
@@ -73,7 +68,7 @@ jobs:
         if: matrix.os == 'ubuntu-20.04'
       - name: Upload the AAR
         if: matrix.os == 'ubuntu-20.04'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: starknet-aar
           path: starknet.aar
@@ -86,7 +81,7 @@ jobs:
         include:
           - virt_platform: arm64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Set up qemu
@@ -107,11 +102,11 @@ jobs:
           tags: build:latest
       - name: Set arch variable
         id: vars
-        run: echo "::set-output name=os_arch::$(docker run --platform linux/${{ matrix.virt_platform }} -t build bash -c 'uname -m')"
+        run: echo "os_arch=$(docker run --platform linux/${{ matrix.virt_platform }} -t build bash -c 'uname -m')" >> $GITHUB_OUTPUT
       - name: Extract lib
         run: docker cp $(docker create build):/build/crypto/build/bindings/libcrypto_jni.so libcrypto_jni.so 
       - name: Upload the shared lib
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: lib-Linux-${{ steps.vars.outputs.os_arch }}
           path: libcrypto_jni.so
@@ -122,7 +117,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [build_x64, build_virt]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@v2
         with:
           path: download
@@ -139,7 +134,7 @@ jobs:
       - name: Rename JAR
         run: mv lib/build/libs/lib-[0-9].[0-9].[0-9].jar starknet.jar
       - name: Upload the JAR
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: starknet-jar
           path: starknet.jar
@@ -148,7 +143,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [build_x64, build_virt]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Generate javadoc JAR
         run: ./gradlew javadocJar
       - name: Generate sources JAR
@@ -156,12 +151,12 @@ jobs:
       - name: Rename JARS
         run: mv lib/build/libs/lib-[0-9].[0-9].[0-9]-javadoc.jar javadoc.jar && mv lib/build/libs/lib-[0-9].[0-9].[0-9]-sources.jar sources.jar
       - name: Upload javadoc JAR
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: javadoc-jar
           path: javadoc.jar
       - name: Upload sources JAR
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: sources-jar
           path: sources.jar
@@ -170,7 +165,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [package_jar, generate_javadoc_and_sources]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
         with:
           path: lib/
@@ -180,7 +175,7 @@ jobs:
           java-version: 11
           distribution: 'corretto'
       - name: Publish package
-        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: publish closeAndReleaseRepository
         env:
@@ -188,10 +183,8 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_signingKey }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_signingPassword }}
-      - uses: marvinpinto/action-automatic-releases@d68defdd11f9dcc7f52f35c1b7c236ee7513bcc1
+      - uses: softprops/action-gh-release@d4e8205d7e959a9107da6396278b2f1f07af0f9b
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          prerelease: false
           files: |
             lib/javadoc-jar/*.jar
             lib/sources-jar/*.jar

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,7 +9,7 @@ jobs:
   test_and_lint:
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest"]
+        os: ["macos-latest", "ubuntu-20.04"]
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -21,7 +21,7 @@ jobs:
           distribution: temurin
           java-version: 11
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.12
+        uses: jwlawson/actions-setup-cmake@4f73d30c2fc44a9466a3ed890fb8db7a7b554302
         with:
           cmake-version: '3.16.x'
       - name: Set up Python 3.9.12


### PR DESCRIPTION
## Describe your changes

This PR adds support for older glibc (3.4.24) for arm architecture + updates gh actions to use newest versions without deprecation warnings. 
It also fixes ubuntu runner version to 20.04, as this is the newest version that easily supports g++-7; It still has ~3 years of support so we should be good. After amazon updates their Linux distros to use newer glibc versions we should think about also updating our runners and dropping older glibc.

## Linked issues

Closes https://github.com/software-mansion/starknet-jvm/issues/189
Closes https://github.com/software-mansion/starknet-jvm/issues/171

## Breaking changes

- [ ] This issue contains breaking changes

