### PR TITLE
Throw an exception when illegal argument is passed in StarkCurve.getPublicKey

### DIFF
--- a/lib/src/main/kotlin/com/swmansion/starknet/crypto/StarknetCurve.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/crypto/StarknetCurve.kt
@@ -192,6 +192,9 @@ object StarknetCurve {
      */
     @JvmStatic
     fun getPublicKey(privateKey: Felt): Felt {
+        if (privateKey == Felt.ZERO) {
+            throw IllegalArgumentException("Private key is invalid")
+        }
         val publicKey = getPublicKey(feltToNative(privateKey)).apply { reverse() }
         return BigInteger(publicKey).toFelt
     }

--- a/lib/src/test/kotlin/starknet/crypto/StarknetCurveTest.kt
+++ b/lib/src/test/kotlin/starknet/crypto/StarknetCurveTest.kt
@@ -95,6 +95,13 @@ internal class StarknetCurveTest {
     }
 
     @Test
+    fun getPublicKeyInvalid() {
+        assertThrows(IllegalArgumentException::class.java) {
+            StarknetCurve.getPublicKey(Felt.ZERO)
+        }
+    }
+
+    @Test
     fun pedersen() {
         val maxFelt = (Felt.PRIME - BigInteger.ONE).toFelt
         // Generated using cairo-lang package


### PR DESCRIPTION
## Describe your changes

Added check in StarknetCurve.getPublicKey that fails if privateKey value is wrong, so exception is thrown from sdk rather than crypto-cpp.

## Linked issues

Closes https://github.com/software-mansion/starknet-jvm/issues/216

## Breaking changes

- [ ] This issue contains breaking changes
