### PR TITLE
Enable parallel test execution

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           cmake-version: '3.16.x'
       - name: Set up Python 3.9.12
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9.12
 
@@ -40,13 +40,10 @@ jobs:
       - name: Lint
         run: ./gradlew :lib:lintKotlin
 
-      - name: Run tests
-        run: ./gradlew :lib:test --info
-
-      - name: Generate coverage report
-        run: ./gradlew :lib:koverXmlReport
+      - name: Run tests and generate coverage report
+        run: ./gradlew :lib:koverXmlReport --info
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
         with:
           files: lib/build/reports/kover/project-xml/report.xml

--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,5 @@ venv
 !gradle/wrapper/gradle-wrapper.jar
 
 # Exclude account temp files
-lib/src/test/resources/account
+lib/src/test/resources/*account
 lib/src/test/resources/compiled

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -84,6 +84,8 @@ tasks.test {
     systemProperty("java.library.path", file("$buildDir/libs/shared").absolutePath)
     systemProperty("java.library.path", file("${rootDir}/crypto/build/bindings").absolutePath)
 
+    maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).takeIf { it > 0 } ?: 1
+
     testLogging {
         events("PASSED", "SKIPPED", "FAILED")
         showStandardStreams = true

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -24,14 +24,15 @@ import starknet.utils.ContractDeployer
 import starknet.utils.DevnetClient
 import java.math.BigInteger
 import java.nio.file.Path
+import java.nio.file.Paths
 import kotlin.io.path.readText
 
 @Execution(ExecutionMode.SAME_THREAD)
 class StandardAccountTest {
     companion object {
         @JvmStatic
-        private val devnetClient = DevnetClient(port = 5051)
-        private val signer = StarkCurveSigner(Felt(1234))
+        private val devnetClient = DevnetClient(port = 5051, accountDirectory = Paths.get("src/test/resources/standard_account_test_account"))
+        private val signer = StarkCurveSigner(Felt(1234567))
 
         private lateinit var gatewayProvider: GatewayProvider
         private lateinit var rpcProvider: JsonRpcProvider

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -16,6 +16,8 @@ import com.swmansion.starknet.signer.StarkCurveSigner
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import starknet.utils.ContractDeployer
@@ -24,6 +26,7 @@ import java.math.BigInteger
 import java.nio.file.Path
 import kotlin.io.path.readText
 
+@Execution(ExecutionMode.SAME_THREAD)
 class StandardAccountTest {
     companion object {
         @JvmStatic

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -32,7 +32,7 @@ class StandardAccountTest {
     companion object {
         @JvmStatic
         private val devnetClient = DevnetClient(port = 5051, accountDirectory = Paths.get("src/test/resources/standard_account_test_account"))
-        private val signer = StarkCurveSigner(Felt(1234567))
+        private val signer = StarkCurveSigner(Felt(1234))
 
         private lateinit var gatewayProvider: GatewayProvider
         private lateinit var rpcProvider: JsonRpcProvider

--- a/lib/src/test/kotlin/starknet/deployercontract/StandardDeployerTest.kt
+++ b/lib/src/test/kotlin/starknet/deployercontract/StandardDeployerTest.kt
@@ -18,12 +18,13 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import starknet.utils.DevnetClient
 import java.nio.file.Path
+import java.nio.file.Paths
 import starknet.utils.ContractDeployer as TestContractDeployer
 
 @Execution(ExecutionMode.SAME_THREAD)
 object StandardDeployerTest {
     @JvmStatic
-    private val devnetClient = DevnetClient(port = 5052)
+    private val devnetClient = DevnetClient(port = 5052, accountDirectory = Paths.get("src/test/resources/standard_deployer_test_account"))
     private val signer = StarkCurveSigner(Felt(1234))
 
     private lateinit var testContractDeployer: TestContractDeployer

--- a/lib/src/test/kotlin/starknet/deployercontract/StandardDeployerTest.kt
+++ b/lib/src/test/kotlin/starknet/deployercontract/StandardDeployerTest.kt
@@ -12,12 +12,15 @@ import com.swmansion.starknet.provider.rpc.JsonRpcProvider
 import com.swmansion.starknet.signer.StarkCurveSigner
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import starknet.utils.DevnetClient
 import java.nio.file.Path
 import starknet.utils.ContractDeployer as TestContractDeployer
 
+@Execution(ExecutionMode.SAME_THREAD)
 object StandardDeployerTest {
     @JvmStatic
     private val devnetClient = DevnetClient(port = 5052)

--- a/lib/src/test/kotlin/starknet/provider/ProviderTest.kt
+++ b/lib/src/test/kotlin/starknet/provider/ProviderTest.kt
@@ -24,11 +24,12 @@ import org.mockito.kotlin.mock
 import starknet.utils.DevnetClient
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.Paths
 
 class ProviderTest {
     companion object {
         @JvmStatic
-        private val devnetClient = DevnetClient()
+        private val devnetClient = DevnetClient(accountDirectory = Paths.get("src/test/resources/provider_test_account"))
         private lateinit var contractAddress: Felt
         private lateinit var classHash: Felt
         private lateinit var invokeTransactionHash: Felt

--- a/lib/src/test/kotlin/starknet/utils/DevnetClient.kt
+++ b/lib/src/test/kotlin/starknet/utils/DevnetClient.kt
@@ -29,8 +29,8 @@ class DevnetClient(
     private val host: String = "0.0.0.0",
     private val port: Int = 5050,
     private val httpService: HttpService = OkHttpService(),
+    private val accountDirectory: Path = Paths.get("src/test/resources/account"),
 ) : AutoCloseable {
-    private val accountDirectory = Paths.get("src/test/resources/account")
     private val baseUrl: String = "http://$host:$port"
     private val seed: Int = 1053545547
     private val json = Json { ignoreUnknownKeys = true }

--- a/lib/src/test/resources/junit-platform.properties
+++ b/lib/src/test/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.default = concurrent


### PR DESCRIPTION
## Describe your changes

<!-- A brief description of the changes introduced in this PR -->

This PR configures most tests modules to run in parallel. 

StandardAccount and StandardDeployer still run in single thread, because parallel execution caused the tests to fail because of the invalid nonces.

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #228 

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
