### PR TITLE
:sparkles: Split PENDING and RECEIVED transaction statuses

### DIFF
--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/TransactionReceipt.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/TransactionReceipt.kt
@@ -15,8 +15,11 @@ enum class TransactionReceiptType {
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable
 enum class TransactionStatus {
-    @JsonNames("PENDING", "RECEIVED")
+    @JsonNames("PENDING")
     PENDING,
+
+    @JsonNames("RECEIVED")
+    RECEIVED,
 
     @JsonNames("ACCEPTED_ON_L1")
     ACCEPTED_ON_L1,

--- a/lib/src/test/kotlin/starknet/data/TransactionStatusMappingTest.kt
+++ b/lib/src/test/kotlin/starknet/data/TransactionStatusMappingTest.kt
@@ -10,11 +10,11 @@ import org.junit.jupiter.api.assertThrows
 class TransactionStatusMappingTest {
 
     @Test
-    fun `received status is mapped to pending`() {
+    fun `received status is mapped to received`() {
         val statusString = "\"RECEIVED\""
         val status = Json.decodeFromString(TransactionStatus.serializer(), statusString)
 
-        assertEquals(TransactionStatus.PENDING, status)
+        assertEquals(TransactionStatus.RECEIVED, status)
     }
 
     @Test


### PR DESCRIPTION
The TransactionStatus enumeration should include a distinction between PENDING and RECEIVED as they represent different statuses.