### PR TITLE
Support signing TypedData

### DIFF
--- a/lib/src/main/kotlin/com/swmansion/starknet/account/Account.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/account/Account.kt
@@ -1,5 +1,6 @@
 package com.swmansion.starknet.account
 
+import com.swmansion.starknet.data.TypedData
 import com.swmansion.starknet.data.types.*
 import com.swmansion.starknet.data.types.transactions.*
 import com.swmansion.starknet.provider.Request
@@ -75,6 +76,23 @@ interface Account {
         params: ExecutionParams,
         forFeeEstimate: Boolean = false,
     ): DeclareTransactionPayload
+
+    /**
+     * Sign TypedData for off-chain usage with this account privateKey
+     *
+     * @param typedData a TypedData instance to sign
+     * @return a signature of typedData provided
+     */
+    fun signTypedData(typedData: TypedData): Signature
+
+    /**
+     * Verify a signature of TypedData on StarkNet
+     *
+     * @param typedData a TypedData instance which signature will be verified
+     * @param signature a signature of typedData
+     * @return `true` if signature is valid, `false` otherwise
+     */
+    fun verifyTypedDataSignature(typedData: TypedData, signature: Signature): Request<Boolean>
 
     /**
      * Execute a list of calls

--- a/lib/src/main/kotlin/com/swmansion/starknet/account/Account.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/account/Account.kt
@@ -23,8 +23,21 @@ interface Account {
      * @param forFeeEstimate when set to `true`, it changes the version to `2^128+version` so the signed transaction can only be used for fee estimation
      * @return signed invoke function payload
      */
-    fun sign(call: Call, params: ExecutionParams, forFeeEstimate: Boolean = false): InvokeTransactionPayload {
+    fun sign(call: Call, params: ExecutionParams, forFeeEstimate: Boolean): InvokeTransactionPayload {
         return sign(listOf(call), params, forFeeEstimate)
+    }
+
+    /**
+     * Sign a transaction.
+     *
+     * Sign a transaction to be executed on StarkNet.
+     *
+     * @param call a call to be signed
+     * @param params additional execution parameters for the transaction
+     * @return signed invoke function payload
+     */
+    fun sign(call: Call, params: ExecutionParams): InvokeTransactionPayload {
+        return sign(listOf(call), params, false)
     }
 
     /**
@@ -37,7 +50,20 @@ interface Account {
      * @param forFeeEstimate when set to `true`, it changes the version to `2^128+version` so the signed transaction can only be used for fee estimation
      * @return signed invoke function payload
      */
-    fun sign(calls: List<Call>, params: ExecutionParams, forFeeEstimate: Boolean = false): InvokeTransactionPayload
+    fun sign(calls: List<Call>, params: ExecutionParams, forFeeEstimate: Boolean): InvokeTransactionPayload
+
+    /**
+     * Sign multiple calls as a single transaction.
+     *
+     * Sign a list of calls to be executed on StarkNet.
+     *
+     * @param calls a list of calls to be signed
+     * @param params additional execution parameters for the transaction
+     * @return signed invoke function payload
+     */
+    fun sign(calls: List<Call>, params: ExecutionParams): InvokeTransactionPayload {
+        return sign(calls, params, false)
+    }
 
     /**
      * Sign deploy account transaction.
@@ -56,8 +82,28 @@ interface Account {
         calldata: Calldata,
         salt: Felt,
         maxFee: Felt,
-        forFeeEstimate: Boolean = false,
+        forFeeEstimate: Boolean,
     ): DeployAccountTransactionPayload
+
+    /**
+     * Sign deploy account transaction.
+     *
+     * Sign a deploy account transaction that requires prefunding deployed address.
+     *
+     * @param classHash hash of the contract that will be deployed. Has to be declared first!
+     * @param calldata constructor calldata for the contract deployment
+     * @param salt salt used to calculate address of the new contract
+     * @param maxFee max fee to be consumed by this transaction
+     * @return signed deploy account payload
+     */
+    fun signDeployAccount(
+        classHash: Felt,
+        calldata: Calldata,
+        salt: Felt,
+        maxFee: Felt,
+    ): DeployAccountTransactionPayload {
+        return signDeployAccount(classHash, calldata, salt, maxFee, false)
+    }
 
     /**
      * Sign a declare transaction.

--- a/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
@@ -140,6 +140,13 @@ class StandardAccount(
         }
     }
 
+    /**
+     * Check if the error message contains part like `Signature ..., is invalid`
+     *
+     * Account contract `isValidSignature` signature raises an error instead of
+     * returning `0` on invalid signature. We have to check the call error to verify
+     * if it was caused by invalid signature or some other problem.
+     */
     private fun handleValidationError(e: RequestFailedException): Boolean {
         val regex = """Signature\s.+,\sis\sinvalid""".toRegex()
         if (e.message?.let { regex.containsMatchIn(it) } == true) {

--- a/lib/src/main/kotlin/com/swmansion/starknet/signer/Signer.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/signer/Signer.kt
@@ -19,9 +19,10 @@ interface Signer {
     fun signTransaction(transaction: Transaction): Signature
 
     /**
-     * Sign TypedData
+     * Sign TypedData.
      *
      * @param typedData TypedData instance to sign
+     * @param accountAddress Account address
      * @return a signature of provided typedData
      */
     fun signTypedData(typedData: TypedData, accountAddress: Felt): Signature

--- a/lib/src/main/kotlin/com/swmansion/starknet/signer/Signer.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/signer/Signer.kt
@@ -22,7 +22,7 @@ interface Signer {
      * Sign TypedData.
      *
      * @param typedData TypedData instance to sign
-     * @param accountAddress Account address
+     * @param accountAddress Account address used in the TypedData hash calculation
      * @return a signature of provided typedData
      */
     fun signTypedData(typedData: TypedData, accountAddress: Felt): Signature

--- a/lib/src/main/kotlin/com/swmansion/starknet/signer/Signer.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/signer/Signer.kt
@@ -1,5 +1,6 @@
 package com.swmansion.starknet.signer
 
+import com.swmansion.starknet.data.TypedData
 import com.swmansion.starknet.data.types.*
 import com.swmansion.starknet.data.types.transactions.*
 
@@ -15,9 +16,15 @@ interface Signer {
      * @param transaction a transaction to be signed
      * @return a signature of provided transaction
      */
-    // TODO: sign message
-    // TODO: add more params
     fun signTransaction(transaction: Transaction): Signature
+
+    /**
+     * Sign TypedData
+     *
+     * @param typedData TypedData instance to sign
+     * @return a signature of provided typedData
+     */
+    fun signTypedData(typedData: TypedData, accountAddress: Felt): Signature
 
     /**
      * Public key used by a signer.

--- a/lib/src/main/kotlin/com/swmansion/starknet/signer/StarkCurveSigner.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/signer/StarkCurveSigner.kt
@@ -1,6 +1,7 @@
 package com.swmansion.starknet.signer
 
 import com.swmansion.starknet.crypto.StarknetCurve
+import com.swmansion.starknet.data.TypedData
 import com.swmansion.starknet.data.types.*
 import com.swmansion.starknet.data.types.transactions.*
 
@@ -16,5 +17,10 @@ class StarkCurveSigner(private val privateKey: Felt) : Signer {
 
     override fun signTransaction(transaction: Transaction): Signature {
         return StarknetCurve.sign(privateKey, transaction.hash).toList()
+    }
+
+    override fun signTypedData(typedData: TypedData, accountAddress: Felt): Signature {
+        val messageHash = typedData.getMessageHash(accountAddress)
+        return StarknetCurve.sign(privateKey, messageHash).toList()
     }
 }


### PR DESCRIPTION
## Describe your changes

<!-- A brief description of the changes introduced in this PR -->

This PR adds support for signing TypedData both in `Account` and `Signer` interfaces

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes

## Breaking changes

- [x] This issue contains breaking changes

* Account interface added `signTypedData` and `verifyTypedDataSignature`
* Signer interface added `signTypedData`

<!-- List all breaking changes introduced by this issue -->
