### PR TITLE
Use blockNumber to get block per tag in gateway

### DIFF
--- a/androiddemo/build.gradle.kts
+++ b/androiddemo/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.4.2")
     implementation("com.google.android.material:material:1.6.1")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
-    implementation("com.swmansion.starknet:starknet:0.5.0@aar")
+    implementation("com.swmansion.starknet:starknet:0.5.1@aar")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.3")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")

--- a/javademo/build.gradle.kts
+++ b/javademo/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    implementation("com.swmansion.starknet:starknet:0.5.0")
+    implementation("com.swmansion.starknet:starknet:0.5.1")
 }
 
 application {

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -8,7 +8,7 @@
 
 import org.jetbrains.dokka.gradle.DokkaTask
 
-version = "0.5.0"
+version = "0.5.1"
 group = "com.swmansion.starknet"
 
 plugins {

--- a/lib/src/main/kotlin/com/swmansion/starknet/provider/gateway/GatewayProvider.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/provider/gateway/GatewayProvider.kt
@@ -272,7 +272,7 @@ class GatewayProvider(
     }
 
     override fun getClassHashAt(contractAddress: Felt, blockTag: BlockTag): Request<Felt> {
-        val param = "blockTag" to blockTag.tag
+        val param = "blockNumber" to blockTag.tag
 
         return getClassHashAt(param, contractAddress)
     }


### PR DESCRIPTION
## Describe your changes

Use `blockNumber` as key in getClassHashAt for blockTag in gateway

## Linked issues

Closes https://github.com/software-mansion/starknet-jvm/issues/241

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
