### PR TITLE
Change url to new repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "crypto/crypto-cpp"]
 	path = crypto/crypto-cpp
-	url = git@github.com:Solpatium/crypto-cpp.git
+	url = git@github.com:software-mansion-labs/crypto-cpp.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
+typeguard~=2.13.3
+Web3~=5.31.1
 starknet-devnet==0.4.2


### PR DESCRIPTION
## Describe your changes

Changed URL to `crypto-cpp` repository to a new one since the old one doesn't exist anymore.
Temporarily added `typeguard` and `Web3` to `requirements.txt` until PR is merged in `cairo-lang`