### PR TITLE
Update estimate message fee to match RPC 0.4.0 schema changes

### DIFF
--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/Messages.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/Messages.kt
@@ -6,7 +6,10 @@ import kotlinx.serialization.json.JsonNames
 
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable
-data class MessageToL1(
+data class MessageL2ToL1(
+    @JsonNames("from_address")
+    val fromAddress: Felt,
+
     @JsonNames("to_address")
     val toAddress: Felt,
 
@@ -16,9 +19,12 @@ data class MessageToL1(
 
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable
-data class MessageToL2(
+data class MessageL1ToL2(
     @JsonNames("from_address")
     val fromAddress: Felt,
+
+    @JsonNames("to_address")
+    val toAddress: Felt,
 
     @JsonNames("payload")
     val payload: List<Felt>,

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/Payloads.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/Payloads.kt
@@ -52,6 +52,15 @@ data class EstimateTransactionFeePayload(
 ) : PayloadWithBlockId()
 
 @Serializable
+data class EstimateMessageFeePayload(
+    @SerialName("message")
+    val message: MessageL1ToL2,
+
+    @SerialName("block_id")
+    override val blockId: BlockId,
+) : PayloadWithBlockId()
+
+@Serializable
 data class GetBlockTransactionCountPayload(
     @SerialName("block_id")
     override val blockId: BlockId,

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/SimulatedTransaction.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/SimulatedTransaction.kt
@@ -5,7 +5,7 @@ import com.swmansion.starknet.data.types.Calldata
 import com.swmansion.starknet.data.types.EstimateFeeResponse
 import com.swmansion.starknet.data.types.EventContent
 import com.swmansion.starknet.data.types.Felt
-import com.swmansion.starknet.data.types.MessageToL1
+import com.swmansion.starknet.data.types.MessageL2ToL1
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -61,7 +61,7 @@ data class FunctionInvocation(
     val events: List<EventContent>?,
 
     @SerialName("messages")
-    val messages: List<MessageToL1>?,
+    val messages: List<MessageL2ToL1>?,
 )
 
 @Serializable

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/TransactionReceipt.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/TransactionReceipt.kt
@@ -2,8 +2,8 @@ package com.swmansion.starknet.data.types.transactions
 
 import com.swmansion.starknet.data.types.Event
 import com.swmansion.starknet.data.types.Felt
-import com.swmansion.starknet.data.types.MessageToL1
-import com.swmansion.starknet.data.types.MessageToL2
+import com.swmansion.starknet.data.types.MessageL1ToL2
+import com.swmansion.starknet.data.types.MessageL2ToL1
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonNames
@@ -64,10 +64,10 @@ data class GatewayTransactionReceipt(
     val events: List<Event>,
 
     @JsonNames("l2_to_l1_messages")
-    val messagesToL1: List<MessageToL1>,
+    val messagesToL1: List<MessageL2ToL1>,
 
     @JsonNames("l1_to_l2_consumed_message")
-    val messageToL2: MessageToL2? = null,
+    val messageL1ToL2: MessageL1ToL2? = null,
 
     @JsonNames("transaction_hash", "txn_hash")
     override val hash: Felt,
@@ -112,7 +112,7 @@ data class RpcTransactionReceipt(
     override val type: TransactionReceiptType,
 
     @JsonNames("messages_sent")
-    val messagesSent: List<MessageToL1>,
+    val messagesSent: List<MessageL2ToL1>,
 
     @JsonNames("events")
     val events: List<Event>,
@@ -140,7 +140,7 @@ data class DeployRpcTransactionReceipt(
     override val type: TransactionReceiptType,
 
     @JsonNames("messages_sent")
-    val messagesSent: List<MessageToL1>,
+    val messagesSent: List<MessageL2ToL1>,
 
     @JsonNames("events")
     val events: List<Event>,
@@ -159,7 +159,7 @@ data class PendingRpcTransactionReceipt(
     override val actualFee: Felt,
 
     @JsonNames("messages_sent")
-    val messagesSent: List<MessageToL1>,
+    val messagesSent: List<MessageL2ToL1>,
 
     @JsonNames("events")
     val events: List<Event>,
@@ -179,7 +179,7 @@ data class PendingRpcDeployTransactionReceipt(
     override val actualFee: Felt,
 
     @JsonNames("messages_sent")
-    val messagesSent: List<MessageToL1>,
+    val messagesSent: List<MessageL2ToL1>,
 
     @JsonNames("events")
     val events: List<Event>,

--- a/lib/src/main/kotlin/com/swmansion/starknet/provider/rpc/JsonRpcProvider.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/provider/rpc/JsonRpcProvider.kt
@@ -397,6 +397,59 @@ class JsonRpcProvider(
 
         return getEstimateFee(estimatePayload)
     }
+    private fun getEstimateMessageFee(payload: EstimateMessageFeePayload): Request<EstimateFeeResponse> {
+        val jsonPayload = jsonWithDefaults.encodeToJsonElement(payload)
+
+        return buildRequest(JsonRpcMethod.ESTIMATE_MESSAGE_FEE, jsonPayload, EstimateFeeResponse.serializer())
+    }
+
+    /**
+     * Estimate a message fee.
+     *
+     * Estimate the L2 fee of a provided message sent on L1.
+     *
+     * @param message message, for which the fee is to be estimated.
+     * @param blockHash a hash of the block in respect to what the query will be made
+     *
+     * @throws RequestFailedException
+     */
+    fun getEstimateMessageFee(message: MessageL1ToL2, blockHash: Felt): Request<EstimateFeeResponse> {
+        val estimatePayload = EstimateMessageFeePayload(message, BlockId.Hash(blockHash))
+
+        return getEstimateMessageFee(estimatePayload)
+    }
+
+    /**
+     * Estimate a message fee.
+     *
+     * Estimate the L2 fee of a provided message sent on L1.
+     *
+     * @param message message, for which the fee is to be estimated.
+     * @param blockNumber a number of the block in respect to what the query will be made
+     *
+     * @throws RequestFailedException
+     */
+    fun getEstimateMessageFee(message: MessageL1ToL2, blockNumber: Int): Request<EstimateFeeResponse> {
+        val estimatePayload = EstimateMessageFeePayload(message, BlockId.Number(blockNumber))
+
+        return getEstimateMessageFee(estimatePayload)
+    }
+
+    /**
+     * Estimate a message fee.
+     *
+     * Estimate the L2 fee of a provided message sent on L1.
+     *
+     * @param message message, for which the fee is to be estimated.
+     * @param blockTag a tag of the block in respect to what the query will be made
+     *
+     * @throws RequestFailedException
+     */
+    fun getEstimateMessageFee(message: MessageL1ToL2, blockTag: BlockTag): Request<EstimateFeeResponse> {
+        val estimatePayload = EstimateMessageFeePayload(message, BlockId.Tag(blockTag))
+
+        return getEstimateMessageFee(estimatePayload)
+    }
 
     private fun getNonce(payload: GetNoncePayload): Request<Felt> {
         val jsonPayload = Json.encodeToJsonElement(payload)
@@ -646,6 +699,7 @@ private enum class JsonRpcMethod(val methodName: String) {
     GET_BLOCK_TRANSACTION_COUNT("starknet_getBlockTransactionCount"),
     GET_SYNCING("starknet_syncing"),
     ESTIMATE_FEE("starknet_estimateFee"),
+    ESTIMATE_MESSAGE_FEE("starknet_estimateMessageFee"),
     GET_BLOCK_WITH_TXS("starknet_getBlockWithTxs"),
     GET_STATE_UPDATE("starknet_getStateUpdate"),
     GET_TRANSACTION_BY_BLOCK_ID_AND_INDEX("starknet_getTransactionByBlockIdAndIndex"),

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -178,7 +178,7 @@ class StandardAccountTest {
         // Note to future developers experiencing failures in this test. Compiled contract format sometimes
         // changes, this causes changes in the class hash.
         // If this test starts randomly falling, try recalculating class hash.
-        val classHash = Felt.fromHex("0x48e8cd3b3d95cb6d9cbc9b3c0a39b1a7341f04b7daa5a13461dbc3116c5423")
+        val classHash = Felt.fromHex("0x37475b8cd1e7360416bae6bc332ba4bc50936cd2d0f9f2207507acbac172e8d")
         val declareTransactionPayload = account.signDeclare(
             contractDefinition,
             classHash,
@@ -212,7 +212,7 @@ class StandardAccountTest {
         // Note to future developers experiencing failures in this test. Compiled contract format sometimes
         // changes, this causes changes in the class hash.
         // If this test starts randomly falling, try recalculating class hash.
-        val classHash = Felt.fromHex("0x48e8cd3b3d95cb6d9cbc9b3c0a39b1a7341f04b7daa5a13461dbc3116c5423")
+        val classHash = Felt.fromHex("0x37475b8cd1e7360416bae6bc332ba4bc50936cd2d0f9f2207507acbac172e8d")
         val declareTransactionPayload = account.signDeclare(
             contractDefinition,
             classHash,

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -201,6 +201,12 @@ class StandardAccountTest {
         assertNotNull(feeEstimate)
     }
 
+    @Test
+    fun `estimate message fee`() {
+        // TODO: test provider.getEstimateMessageFee
+        // BLOCKED: pending devnet update
+    }
+
     @ParameterizedTest
     @MethodSource("getAccounts")
     fun `sign and send declare transaction`(accountAndProvider: AccountAndProvider) {

--- a/lib/src/test/kotlin/starknet/provider/ProviderTest.kt
+++ b/lib/src/test/kotlin/starknet/provider/ProviderTest.kt
@@ -1071,9 +1071,9 @@ class ProviderTest {
 
         assertEquals(hash, receipt.hash)
         assertEquals(TransactionStatus.PENDING, receipt.status)
-        assertEquals(emptyList<MessageToL1>(), receipt.messagesToL1)
+        assertEquals(emptyList<MessageL2ToL1>(), receipt.messagesToL1)
         assertEquals(emptyList<Event>(), receipt.events)
-        assertNull(receipt.messageToL2)
+        assertNull(receipt.messageL1ToL2)
         assertNull(receipt.actualFee)
         assertNull(receipt.failureReason)
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-starknet-devnet==v0.5.3
+starknet-devnet==v0.5.5


### PR DESCRIPTION
## Describe your changes

- Update estimate message fee to match RPC 0.4.0 schema changes
- Blocked until can be further tested (pending devnet update)

<!-- A brief description of the changes introduced in this PR -->

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #270 

## Breaking changes

- [x] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
