### PR TITLE
Add caching on CI for Python and Rust deps

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,12 +27,14 @@ jobs:
         uses: jwlawson/actions-setup-cmake@4f73d30c2fc44a9466a3ed890fb8db7a7b554302
         with:
           cmake-version: '3.16.x'
-      - name: Set up Python 3.9.12 and devnet
+      - name: Set up Python 3.9.12
         uses: actions/setup-python@v4.5.0
         with:
           python-version: 3.9.12
           cache: 'pip'
-      - run: |
+
+      - name: Install devnet
+        run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 

--- a/lib/src/test/resources/compileContracts.sh
+++ b/lib/src/test/resources/compileContracts.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 pushd "$(dirname "$0")" || exit
-
 mkdir -p "compiled_v0"
 
 echo "Compiling v0 contracts.."


### PR DESCRIPTION
## Describe your changes
- [x] Locally cache compiled contracts.
- [x] Cache python deps on gh actions.
- [x] Cache cairo rust deps on gh actions. 
- [ ] Cache contracts on gh actions. 
- [ ] Cache poseidon and petersen on gh actions.
<!-- A brief description of the changes introduced in this PR -->

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #256 

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
