### PR TITLE
Update simulateTransactions to match RPC 0.4

### DIFF
--- a/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/JsonRpcTransactionTracePolymorphicSerializer.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/JsonRpcTransactionTracePolymorphicSerializer.kt
@@ -13,7 +13,7 @@ internal object JsonRpcTransactionTracePolymorphicSerializer :
             setOf("validate_invocation", "execute_invocation", "fee_transfer_invocation") -> InvokeTransactionTrace.serializer()
             setOf("validate_invocation", "fee_transfer_invocation") -> DeclareTransactionTrace.serializer()
             setOf("validate_invocation", "constructor_invocation", "fee_transfer_invocation") -> DeployAccountTransactionTrace.serializer()
-            setOf("functionInvocation") -> L1HandlerTransactionTrace.serializer()
+            setOf("function_invocation") -> L1HandlerTransactionTrace.serializer()
             else -> throw IllegalArgumentException("Invalid transaction trace type")
         }
     }

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/SimulatedTransaction.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/SimulatedTransaction.kt
@@ -25,7 +25,7 @@ enum class CallType(val value: String) {
 @Serializable
 enum class SimulationFlag(val value: String) {
     SKIP_VALIDATE("SKIP_VALIDATE"),
-    SKIP_EXECUTE("SKIP_EXECUTE"),
+    SKIP_FEE_CHARGE("SKIP_FEE_CHARGE"),
 }
 
 @Serializable

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/TransactionPayload.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/TransactionPayload.kt
@@ -11,8 +11,7 @@ sealed class TransactionPayload() {
 }
 
 @Serializable
-data class InvokeTransactionPayload constructor(
-
+data class InvokeTransactionPayload(
     @SerialName("sender_address")
     val senderAddress: Felt,
 

--- a/lib/src/main/kotlin/com/swmansion/starknet/provider/rpc/JsonRpcProvider.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/provider/rpc/JsonRpcProvider.kt
@@ -748,5 +748,5 @@ private enum class JsonRpcMethod(val methodName: String) {
     GET_PENDING_TRANSACTIONS("starknet_pendingTransactions"),
     GET_NONCE("starknet_getNonce"),
     DEPLOY_ACCOUNT_TRANSACTION("starknet_addDeployAccountTransaction"),
-    SIMULATE_TRANSACTIONS("starknet_simulateTransaction"),
+    SIMULATE_TRANSACTIONS("starknet_simulateTransactions"),
 }

--- a/lib/src/test/kotlin/integration/account/AccountTest.kt
+++ b/lib/src/test/kotlin/integration/account/AccountTest.kt
@@ -151,7 +151,7 @@ class AccountTest {
         // 2. If it fails on CI, make sure to delete the compiled contracts before running this test.
         // Chances are, the contract was compiled with a different compiler version.
 
-        val classHash = Felt.fromHex("0x661efb55f8bcf34ad1596936b631e6b581bfa246b99ff3f9f2d9b8fa4ff5962")
+        val classHash = Felt.fromHex("0x3b32bb615844ea7a9a56a8966af1a5ba1457b1f5c9162927ca1968975b0d2a9")
         val declareTransactionPayload = account.signDeclare(
             contractDefinition,
             classHash,
@@ -250,7 +250,7 @@ class AccountTest {
         // 2. If it fails on CI, make sure to delete the compiled contracts before running this test.
         // Chances are, the contract was compiled with a different compiler version.
 
-        val classHash = Felt.fromHex("0x661efb55f8bcf34ad1596936b631e6b581bfa246b99ff3f9f2d9b8fa4ff5962")
+        val classHash = Felt.fromHex("0x3b32bb615844ea7a9a56a8966af1a5ba1457b1f5c9162927ca1968975b0d2a9")
         val declareTransactionPayload = account.signDeclare(
             contractDefinition,
             classHash,

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -733,8 +733,6 @@ class StandardAccountTest {
         }
     }
 
-    // TODO: Re-enable if devnet.py is updated to support this or devnet-rs is released and supports trace api
-    @Disabled
     @Test
     fun `simulate transactions`() {
         val account = StandardAccount(accountAddress, signer, rpcProvider)

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -17,7 +17,6 @@ import com.swmansion.starknet.signer.StarkCurveSigner
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -179,7 +179,7 @@ class StandardAccountTest {
         // Note to future developers experiencing failures in this test. Compiled contract format sometimes
         // changes, this causes changes in the class hash.
         // If this test starts randomly falling, try recalculating class hash.
-        val classHash = Felt.fromHex("0x661efb55f8bcf34ad1596936b631e6b581bfa246b99ff3f9f2d9b8fa4ff5962")
+        val classHash = Felt.fromHex("0x3b32bb615844ea7a9a56a8966af1a5ba1457b1f5c9162927ca1968975b0d2a9")
         val declareTransactionPayload = account.signDeclare(
             contractDefinition,
             classHash,
@@ -275,7 +275,7 @@ class StandardAccountTest {
         // 2. If it fails on CI, make sure to delete the compiled contracts before running this test.
         // Chances are, the contract was compiled with a different compiler version.
 
-        val classHash = Felt.fromHex("0x661efb55f8bcf34ad1596936b631e6b581bfa246b99ff3f9f2d9b8fa4ff5962")
+        val classHash = Felt.fromHex("0x3b32bb615844ea7a9a56a8966af1a5ba1457b1f5c9162927ca1968975b0d2a9")
         val declareTransactionPayload = account.signDeclare(
             contractDefinition,
             classHash,

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -733,8 +733,8 @@ class StandardAccountTest {
         }
     }
 
+    // TODO: Re-enable if devnet.py is updated to support this or devnet-rs is released and supports trace api
     @Disabled
-    // TODO: Re-enable if devnet.py is updated to support this
     @Test
     fun `simulate transactions`() {
         val account = StandardAccount(accountAddress, signer, rpcProvider)

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -17,6 +17,7 @@ import com.swmansion.starknet.signer.StarkCurveSigner
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode
@@ -732,6 +733,8 @@ class StandardAccountTest {
         }
     }
 
+    @Disabled
+    // TODO: Re-enable if devnet.py is updated to support this
     @Test
     fun `simulate transactions`() {
         val account = StandardAccount(accountAddress, signer, rpcProvider)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-starknet-devnet==v0.6.0
+starknet-devnet==v0.6.2


### PR DESCRIPTION
## Describe your changes

<!-- A brief description of the changes introduced in this PR -->
- [x] Change endpoint name `starknet_simulateTransaction` to `starknet_simulateTransactions`
- [x] Bump devnet to 0.6.2 (supports `starknet_simulateTransaction`)
- [x]  Simulation Flags: remove `SKIP_EXECUTE`, add `SKIP_FEE_CHARGE` 
- [ ] ~Change deserializer - none of the properties seem to be required~

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #307 

## Breaking changes

- [x] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
Not compatible with `starknet_simulateTransaction` (RPC 0.3)
