### PR TITLE
Adjust `simulateTransactions` (#323, #314)

### DIFF
--- a/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/JsonRpcTransactionTracePolymorphicSerializer.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/JsonRpcTransactionTracePolymorphicSerializer.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.json.*
 internal object JsonRpcTransactionTracePolymorphicSerializer :
     JsonContentPolymorphicSerializer<TransactionTrace>(TransactionTrace::class) {
     private fun selectInvokeTransactionTraceDeserializer(jsonObject: JsonObject): DeserializationStrategy<out InvokeTransactionTrace> {
-        val executeInvocation = jsonObject["execute_invocation"]?.jsonObject ?: throw IllegalStateException("Invalid INVOKE_TXN_TRACE in response: execute_invocation is missing.")
+        val executeInvocation = jsonObject["execute_invocation"]?.jsonObject ?: throw IllegalStateException("Response from node contains invalid INVOKE_TXN_TRACE: execute_invocation is missing.")
         val isReverted = "revert_reason" in executeInvocation
 
         return when (isReverted) {

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/JsonRpcTransactionTracePolymorphicSerializer.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/JsonRpcTransactionTracePolymorphicSerializer.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.json.*
 internal object JsonRpcTransactionTracePolymorphicSerializer :
     JsonContentPolymorphicSerializer<TransactionTrace>(TransactionTrace::class) {
     private fun selectInvokeTransactionTraceDeserializer(jsonObject: JsonObject): DeserializationStrategy<out InvokeTransactionTrace> {
-        val executeInvocation = jsonObject["execute_invocation"]?.jsonObject ?: throw IllegalStateException("execute_invocation is missing.")
+        val executeInvocation = jsonObject["execute_invocation"]?.jsonObject ?: throw IllegalStateException("Invalid INVOKE_TXN_TRACE in response: execute_invocation is missing.")
         val isReverted = "revert_reason" in executeInvocation
 
         return when (isReverted) {

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/JsonRpcTransactionTracePolymorphicSerializer.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/JsonRpcTransactionTracePolymorphicSerializer.kt
@@ -6,15 +6,25 @@ import kotlinx.serialization.json.*
 
 internal object JsonRpcTransactionTracePolymorphicSerializer :
     JsonContentPolymorphicSerializer<TransactionTrace>(TransactionTrace::class) {
+    private fun selectInvokeTransactionTraceDeserializer(jsonObject: JsonObject): DeserializationStrategy<out InvokeTransactionTrace> {
+        val executeInvocation = jsonObject["execute_invocation"]?.jsonObject ?: throw IllegalStateException("execute_invocation is missing.")
+        val isReverted = "revert_reason" in executeInvocation
+
+        return when (isReverted) {
+            true -> RevertedInvokeTransactionTrace.serializer()
+            false -> CommonInvokeTransactionTrace.serializer()
+        }
+    }
+
     override fun selectDeserializer(element: JsonElement): DeserializationStrategy<out TransactionTrace> {
         val jsonObject = element.jsonObject
 
-        return when (jsonObject.keys) {
-            setOf("validate_invocation", "execute_invocation", "fee_transfer_invocation") -> InvokeTransactionTrace.serializer()
-            setOf("validate_invocation", "fee_transfer_invocation") -> DeclareTransactionTrace.serializer()
-            setOf("validate_invocation", "constructor_invocation", "fee_transfer_invocation") -> DeployAccountTransactionTrace.serializer()
-            setOf("function_invocation") -> L1HandlerTransactionTrace.serializer()
-            else -> throw IllegalArgumentException("Invalid transaction trace type")
+        return when {
+            "execute_invocation" in jsonObject -> selectInvokeTransactionTraceDeserializer(jsonObject)
+            "constructor_invocation" in jsonObject -> DeployAccountTransactionTrace.serializer()
+            "function_invocation" in jsonObject -> L1HandlerTransactionTrace.serializer()
+            listOf("validate_invocation", "fee_transfer_invocation").any { it in jsonObject } -> DeclareTransactionTrace.serializer()
+            else -> throw IllegalStateException("Unknown transaction trace type.")
         }
     }
 }

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/JsonRpcTransactionTracePolymorphicSerializer.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/JsonRpcTransactionTracePolymorphicSerializer.kt
@@ -6,13 +6,13 @@ import kotlinx.serialization.json.*
 
 internal object JsonRpcTransactionTracePolymorphicSerializer :
     JsonContentPolymorphicSerializer<TransactionTrace>(TransactionTrace::class) {
-    private fun selectInvokeTransactionTraceDeserializer(jsonObject: JsonObject): DeserializationStrategy<out InvokeTransactionTrace> {
+    private fun selectInvokeTransactionTraceDeserializer(jsonObject: JsonObject): DeserializationStrategy<out InvokeTransactionTraceBase> {
         val executeInvocation = jsonObject["execute_invocation"]?.jsonObject ?: throw IllegalStateException("Response from node contains invalid INVOKE_TXN_TRACE: execute_invocation is missing.")
         val isReverted = "revert_reason" in executeInvocation
 
         return when (isReverted) {
             true -> RevertedInvokeTransactionTrace.serializer()
-            false -> CommonInvokeTransactionTrace.serializer()
+            false -> InvokeTransactionTrace.serializer()
         }
     }
 

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/SimulatedTransaction.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/SimulatedTransaction.kt
@@ -65,45 +65,72 @@ data class FunctionInvocation(
 )
 
 @Serializable
-sealed class TransactionTrace()
+data class RevertedFunctionInvocation(
+    @SerialName("revert_reason")
+    val revertReason: String,
+)
 
 @Serializable
-data class InvokeTransactionTrace(
-    @SerialName("validate_invocation")
-    val validateInvocation: FunctionInvocation?,
+sealed class TransactionTrace
 
-    @SerialName("execute_invocation")
-    val executeInvocation: FunctionInvocation?,
+@Serializable
+sealed class InvokeTransactionTrace : TransactionTrace() {
+    @SerialName("validate_invocation")
+    abstract val validateInvocation: FunctionInvocation?
 
     @SerialName("fee_transfer_invocation")
-    val feeTransferInvocation: FunctionInvocation?,
-) : TransactionTrace()
+    abstract val feeTransferInvocation: FunctionInvocation?
+}
+
+@Serializable
+data class CommonInvokeTransactionTrace(
+    @SerialName("validate_invocation")
+    override val validateInvocation: FunctionInvocation? = null,
+
+    @SerialName("execute_invocation")
+    val executeInvocation: FunctionInvocation? = null,
+
+    @SerialName("fee_transfer_invocation")
+    override val feeTransferInvocation: FunctionInvocation? = null,
+) : InvokeTransactionTrace()
+
+@Serializable
+data class RevertedInvokeTransactionTrace(
+    @SerialName("validate_invocation")
+    override val validateInvocation: FunctionInvocation? = null,
+
+    @SerialName("execute_invocation")
+    val executeInvocation: RevertedFunctionInvocation? = null,
+
+    @SerialName("fee_transfer_invocation")
+    override val feeTransferInvocation: FunctionInvocation? = null,
+) : InvokeTransactionTrace()
 
 @Serializable
 data class DeclareTransactionTrace(
     @SerialName("validate_invocation")
-    val validateInvocation: FunctionInvocation?,
+    val validateInvocation: FunctionInvocation? = null,
 
     @SerialName("fee_transfer_invocation")
-    val feeTransferInvocation: FunctionInvocation?,
+    val feeTransferInvocation: FunctionInvocation? = null,
 ) : TransactionTrace()
 
 @Serializable
 data class DeployAccountTransactionTrace(
     @SerialName("validate_invocation")
-    val validateInvocation: FunctionInvocation?,
+    val validateInvocation: FunctionInvocation? = null,
 
     @SerialName("constructor_invocation")
-    val constructorInvocation: FunctionInvocation?,
+    val constructorInvocation: FunctionInvocation? = null,
 
     @SerialName("fee_transfer_invocation")
-    val feeTransferInvocation: FunctionInvocation?,
+    val feeTransferInvocation: FunctionInvocation? = null,
 ) : TransactionTrace()
 
 @Serializable
 data class L1HandlerTransactionTrace(
     @SerialName("function_invocation")
-    val functionInvocation: FunctionInvocation?,
+    val functionInvocation: FunctionInvocation? = null,
 ) : TransactionTrace()
 
 @Serializable

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/SimulatedTransaction.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/SimulatedTransaction.kt
@@ -71,7 +71,7 @@ data class RevertedFunctionInvocation(
 )
 
 @Serializable
-sealed class TransactionTrace
+sealed class TransactionTrace()
 
 @Serializable
 sealed class InvokeTransactionTrace : TransactionTrace() {

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/SimulatedTransaction.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/SimulatedTransaction.kt
@@ -74,7 +74,7 @@ data class RevertedFunctionInvocation(
 sealed class TransactionTrace()
 
 @Serializable
-sealed class InvokeTransactionTrace : TransactionTrace() {
+sealed class InvokeTransactionTraceBase : TransactionTrace() {
     @SerialName("validate_invocation")
     abstract val validateInvocation: FunctionInvocation?
 
@@ -83,7 +83,7 @@ sealed class InvokeTransactionTrace : TransactionTrace() {
 }
 
 @Serializable
-data class CommonInvokeTransactionTrace(
+data class InvokeTransactionTrace(
     @SerialName("validate_invocation")
     override val validateInvocation: FunctionInvocation? = null,
 
@@ -92,7 +92,7 @@ data class CommonInvokeTransactionTrace(
 
     @SerialName("fee_transfer_invocation")
     override val feeTransferInvocation: FunctionInvocation? = null,
-) : InvokeTransactionTrace()
+) : InvokeTransactionTraceBase()
 
 @Serializable
 data class RevertedInvokeTransactionTrace(
@@ -104,7 +104,7 @@ data class RevertedInvokeTransactionTrace(
 
     @SerialName("fee_transfer_invocation")
     override val feeTransferInvocation: FunctionInvocation? = null,
-) : InvokeTransactionTrace()
+) : InvokeTransactionTraceBase()
 
 @Serializable
 data class DeclareTransactionTrace(

--- a/lib/src/test/kotlin/integration/account/AccountTest.kt
+++ b/lib/src/test/kotlin/integration/account/AccountTest.kt
@@ -580,8 +580,8 @@ class AccountTest {
             simulationFlags = simulationFlags,
         ).send()
         assertEquals(2, simulationResult.size)
+        assertTrue(simulationResult[0].transactionTrace is InvokeTransactionTraceBase)
         assertTrue(simulationResult[0].transactionTrace is InvokeTransactionTrace)
-        assertTrue(simulationResult[0].transactionTrace is CommonInvokeTransactionTrace)
         assertTrue(simulationResult[1].transactionTrace is DeployAccountTransactionTrace)
 
         val invokeTxWithoutSignature = InvokeTransactionPayload(invokeTx.senderAddress, invokeTx.calldata, emptyList(), invokeTx.maxFee, invokeTx.version, invokeTx.nonce)
@@ -595,8 +595,8 @@ class AccountTest {
         ).send()
 
         assertEquals(2, simulationResult2.size)
+        assertTrue(simulationResult[0].transactionTrace is InvokeTransactionTraceBase)
         assertTrue(simulationResult[0].transactionTrace is InvokeTransactionTrace)
-        assertTrue(simulationResult[0].transactionTrace is CommonInvokeTransactionTrace)
         assertTrue(simulationResult[1].transactionTrace is DeployAccountTransactionTrace)
     }
 

--- a/lib/src/test/kotlin/integration/account/AccountTest.kt
+++ b/lib/src/test/kotlin/integration/account/AccountTest.kt
@@ -535,4 +535,149 @@ class AccountTest {
         val receipt = provider.getTransactionReceipt(response.transactionHash).send()
         assertTrue(receipt.isAccepted)
     }
+
+    @ParameterizedTest
+    @MethodSource("getConstNonceAccounts")
+    fun `simulate invoke and deploy account transactions`(accountAndProvider: AccountAndProvider) {
+        assumeTrue(IntegrationConfig.isTestEnabled(requiresGas = false))
+        val (account, sourceProvider) = accountAndProvider
+        assumeTrue(sourceProvider is JsonRpcProvider)
+        val provider = sourceProvider as JsonRpcProvider
+
+        val nonce = account.getNonce().send()
+        val call = Call(
+            contractAddress = predeployedMapContractAddress,
+            entrypoint = "put",
+            calldata = listOf(
+                Felt(101),
+                Felt(2137),
+            ),
+        )
+        val params = ExecutionParams(nonce, Felt(1000000000))
+        val invokeTx = account.sign(call, params)
+
+        val privateKey = Felt(System.currentTimeMillis())
+        val publicKey = StarknetCurve.getPublicKey(privateKey)
+
+        val classHash = accountContractClassHash
+        val salt = Felt(System.currentTimeMillis())
+        val calldata = listOf(publicKey)
+        val deployedAccountAddress = ContractAddressCalculator.calculateAddressFromHash(classHash, calldata, salt)
+
+        val deployedAccount = StandardAccount(deployedAccountAddress, privateKey, provider)
+        val deployAccountTx = deployedAccount.signDeployAccount(
+            classHash = classHash,
+            salt = salt,
+            calldata = calldata,
+            maxFee = Felt.fromHex("0x11fcc58c7f7000"),
+        )
+
+        // Pathfinder currently always requires SKIP_FEE_CHARGE flag
+        val simulationFlags = setOf(SimulationFlag.SKIP_FEE_CHARGE)
+        val simulationResult = provider.simulateTransactions(
+            transactions = listOf(invokeTx, deployAccountTx),
+            blockTag = BlockTag.LATEST,
+            simulationFlags = simulationFlags,
+        ).send()
+        assertEquals(2, simulationResult.size)
+        assertTrue(simulationResult[0].transactionTrace is InvokeTransactionTrace)
+        assertTrue(simulationResult[0].transactionTrace is CommonInvokeTransactionTrace)
+        assertTrue(simulationResult[1].transactionTrace is DeployAccountTransactionTrace)
+
+        val invokeTxWithoutSignature = InvokeTransactionPayload(invokeTx.senderAddress, invokeTx.calldata, emptyList(), invokeTx.maxFee, invokeTx.version, invokeTx.nonce)
+        val deployAccountTxWithoutSignature = DeployAccountTransactionPayload(deployAccountTx.classHash, deployAccountTx.salt, deployAccountTx.constructorCalldata, deployAccountTx.version, deployAccountTx.nonce, deployAccountTx.maxFee, emptyList())
+
+        val simulationFlags2 = setOf(SimulationFlag.SKIP_FEE_CHARGE, SimulationFlag.SKIP_VALIDATE)
+        val simulationResult2 = provider.simulateTransactions(
+            transactions = listOf(invokeTxWithoutSignature, deployAccountTxWithoutSignature),
+            blockTag = BlockTag.LATEST,
+            simulationFlags = simulationFlags2,
+        ).send()
+
+        assertEquals(2, simulationResult2.size)
+        assertTrue(simulationResult[0].transactionTrace is InvokeTransactionTrace)
+        assertTrue(simulationResult[0].transactionTrace is CommonInvokeTransactionTrace)
+        assertTrue(simulationResult[1].transactionTrace is DeployAccountTransactionTrace)
+    }
+
+    @ParameterizedTest
+    @MethodSource("getConstNonceAccounts")
+    fun `simulate declare v1 transaction`(accountAndProvider: AccountAndProvider) {
+        assumeTrue(IntegrationConfig.isTestEnabled(requiresGas = false))
+        val (account, sourceProvider) = accountAndProvider
+        assumeTrue(sourceProvider is JsonRpcProvider)
+        val provider = sourceProvider as JsonRpcProvider
+
+        val contractCode = Path.of("src/test/resources/contracts_v0/target/release/providerTest.json").readText()
+        val contractDefinition = Cairo0ContractDefinition(contractCode)
+        val nonce = account.getNonce().send()
+
+        // Note to future developers experiencing failures in this test.
+        // 1. Compiled contract format sometimes changes, this causes changes in the class hash.
+        // If this test starts randomly falling, try recalculating class hash.
+        // 2. If it fails on CI, make sure to delete the compiled contracts before running this test.
+        // Chances are, the contract was compiled with a different compiler version.
+
+        val classHash = Felt.fromHex("0x3b32bb615844ea7a9a56a8966af1a5ba1457b1f5c9162927ca1968975b0d2a9")
+        val declareTransactionPayload = account.signDeclare(
+            contractDefinition,
+            classHash,
+            ExecutionParams(
+                nonce = nonce,
+                maxFee = Felt(1000000000000000L),
+            ),
+        )
+
+        // Pathfinder currently always requires SKIP_FEE_CHARGE flag
+        val simulationFlags = setOf(SimulationFlag.SKIP_FEE_CHARGE)
+        val simulationResult = provider.simulateTransactions(
+            transactions = listOf(declareTransactionPayload),
+            blockTag = BlockTag.LATEST,
+            simulationFlags = simulationFlags,
+        ).send()
+        assertEquals(1, simulationResult.size)
+        val trace = simulationResult.first().transactionTrace
+        assertTrue(trace is DeclareTransactionTrace)
+    }
+
+    @ParameterizedTest
+    @MethodSource("getConstNonceAccounts")
+    fun `simulate declare v2 transaction`(accountAndProvider: AccountAndProvider) {
+        assumeTrue(IntegrationConfig.isTestEnabled(requiresGas = false))
+        val (account, sourceProvider) = accountAndProvider
+        assumeTrue(sourceProvider is JsonRpcProvider)
+        val provider = sourceProvider as JsonRpcProvider
+
+        ScarbClient.createSaltedContract(
+            placeholderContractPath = Path.of("src/test/resources/contracts_v1/src/placeholder_hello_starknet.cairo"),
+            saltedContractPath = Path.of("src/test/resources/contracts_v1/src/salted_hello_starknet.cairo"),
+        )
+        ScarbClient.buildContracts(Path.of("src/test/resources/contracts_v1"))
+        val contractCode = Path.of("src/test/resources/contracts_v1/target/release/ContractsV1_SaltedHelloStarknet.sierra.json").readText()
+        val casmCode = Path.of("src/test/resources/contracts_v1/target/release/ContractsV1_SaltedHelloStarknet.casm.json").readText()
+
+        val contractDefinition = Cairo1ContractDefinition(contractCode)
+        val casmContractDefinition = CasmContractDefinition(casmCode)
+
+        val nonce = account.getNonce().send()
+        val declareTransactionPayload = account.signDeclare(
+            contractDefinition,
+            casmContractDefinition,
+            ExecutionParams(
+                nonce = nonce,
+                maxFee = Felt(1000000000000000L),
+            ),
+        )
+
+        // Pathfinder currently always requires SKIP_FEE_CHARGE flag
+        val simulationFlags = setOf(SimulationFlag.SKIP_FEE_CHARGE)
+        val simulationResult = provider.simulateTransactions(
+            transactions = listOf(declareTransactionPayload),
+            blockTag = BlockTag.LATEST,
+            simulationFlags = simulationFlags,
+        ).send()
+        assertEquals(1, simulationResult.size)
+        val trace = simulationResult.first().transactionTrace
+        assertTrue(trace is DeclareTransactionTrace)
+    }
 }

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -30,6 +30,7 @@ import starknet.data.loadTypedData
 import starknet.utils.DevnetClient
 import starknet.utils.LegacyContractDeployer
 import starknet.utils.LegacyDevnetClient
+import starknet.utils.ScarbClient
 import java.math.BigInteger
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -774,7 +775,7 @@ class StandardAccountTest {
     }
 
     @Test
-    fun `simulate transactions`() {
+    fun `simulate invoke and deploy account transactions`() {
         val addressBook = legacyDevnetAddressBook
         val accountAddress = addressBook.accountAddress
         val balanceContractAddress = addressBook.balanceContractAddress
@@ -788,10 +789,7 @@ class StandardAccountTest {
             entrypoint = "increase_balance",
             calldata = listOf(Felt(1000)),
         )
-        val params = ExecutionParams(
-            nonce = nonce,
-            maxFee = Felt(1000000000000000),
-        )
+        val params = ExecutionParams(nonce, Felt(1000000000))
 
         val invokeTx = account.sign(call, params)
 
@@ -826,6 +824,7 @@ class StandardAccountTest {
         ).send()
         assertEquals(2, simulationResult.size)
         assertTrue(simulationResult[0].transactionTrace is InvokeTransactionTrace)
+        assertTrue(simulationResult[0].transactionTrace is CommonInvokeTransactionTrace)
         assertTrue(simulationResult[1].transactionTrace is DeployAccountTransactionTrace)
 
         val invokeTxWithoutSignature = InvokeTransactionPayload(invokeTx.senderAddress, invokeTx.calldata, emptyList(), invokeTx.maxFee, invokeTx.version, invokeTx.nonce)
@@ -840,6 +839,133 @@ class StandardAccountTest {
 
         assertEquals(2, simulationResult2.size)
         assertTrue(simulationResult[0].transactionTrace is InvokeTransactionTrace)
+        assertTrue(simulationResult[0].transactionTrace is CommonInvokeTransactionTrace)
         assertTrue(simulationResult[1].transactionTrace is DeployAccountTransactionTrace)
+    }
+
+    @Test
+    fun `simulate declare v1 transaction`() {
+        val provider = legacyRpcProvider
+        val account = StandardAccount(legacyDevnetAddressBook.accountAddress, legacySigner, provider)
+
+        val contractCode = Path.of("src/test/resources/contracts_v0/target/release/providerTest.json").readText()
+        val contractDefinition = Cairo0ContractDefinition(contractCode)
+        val nonce = account.getNonce().send()
+
+        // Note to future developers experiencing failures in this test.
+        // 1. Compiled contract format sometimes changes, this causes changes in the class hash.
+        // If this test starts randomly falling, try recalculating class hash.
+        // 2. If it fails on CI, make sure to delete the compiled contracts before running this test.
+        // Chances are, the contract was compiled with a different compiler version.
+
+        val classHash = Felt.fromHex("0x3b32bb615844ea7a9a56a8966af1a5ba1457b1f5c9162927ca1968975b0d2a9")
+        val declareTransactionPayload = account.signDeclare(
+            contractDefinition,
+            classHash,
+            ExecutionParams(
+                nonce = nonce,
+                maxFee = Felt(1000000000000000L),
+            ),
+        )
+        val simulationFlags = setOf<SimulationFlag>()
+        val simulationResult = provider.simulateTransactions(
+            transactions = listOf(declareTransactionPayload),
+            blockTag = BlockTag.LATEST,
+            simulationFlags = simulationFlags,
+        ).send()
+        assertEquals(1, simulationResult.size)
+        val trace = simulationResult.first().transactionTrace
+        assertTrue(trace is DeclareTransactionTrace)
+    }
+
+    @Test
+    fun `simulate declare v2 transaction`() {
+        val provider = legacyRpcProvider
+        val account = StandardAccount(legacyDevnetAddressBook.accountAddress, legacySigner, provider)
+
+        ScarbClient.createSaltedContract(
+            placeholderContractPath = Path.of("src/test/resources/contracts_v1/src/placeholder_hello_starknet.cairo"),
+            saltedContractPath = Path.of("src/test/resources/contracts_v1/src/salted_hello_starknet.cairo"),
+        )
+        ScarbClient.buildContracts(Path.of("src/test/resources/contracts_v1"))
+        val contractCode = Path.of("src/test/resources/contracts_v1/target/release/ContractsV1_SaltedHelloStarknet.sierra.json").readText()
+        val casmCode = Path.of("src/test/resources/contracts_v1/target/release/ContractsV1_SaltedHelloStarknet.casm.json").readText()
+
+        val contractDefinition = Cairo1ContractDefinition(contractCode)
+        val casmContractDefinition = CasmContractDefinition(casmCode)
+
+        val nonce = account.getNonce().send()
+        val declareTransactionPayload = account.signDeclare(
+            contractDefinition,
+            casmContractDefinition,
+            ExecutionParams(
+                nonce = nonce,
+                maxFee = Felt(1000000000000000L),
+            ),
+        )
+
+        val simulationFlags = setOf<SimulationFlag>()
+        val simulationResult = provider.simulateTransactions(
+            transactions = listOf(declareTransactionPayload),
+            blockTag = BlockTag.LATEST,
+            simulationFlags = simulationFlags,
+        ).send()
+        assertEquals(1, simulationResult.size)
+        val trace = simulationResult.first().transactionTrace
+        assertTrue(trace is DeclareTransactionTrace)
+    }
+
+    // TODO: replace this with a proper devnet test
+    // Legacy devnet never returns invoke transaction trace that has revert_reason field in execution_invocation.
+    @Test
+    fun `simulate reverted invoke transaction`() {
+        val mockedResponse = """
+        {
+            "jsonrpc": "2.0",
+            "id": 0,
+            "result": [
+                {
+                    "fee_estimation": {
+                        "gas_consumed": "0x9d8",
+                        "gas_price": "0x3b9aca2f",
+                        "overall_fee": "0x24abbb63ea8"
+                    },
+                    "transaction_trace": {
+                        "execute_invocation": {
+                           "revert_reason": "Placeholder revert reason."
+                        }
+                    }
+                }
+            ]
+        }
+        """.trimIndent()
+        val httpService = mock<HttpService> {
+            on { send(any()) } doReturn HttpResponse(true, 200, mockedResponse)
+        }
+        val mockProvider = JsonRpcProvider(legacyDevnetClient.rpcUrl, StarknetChainId.TESTNET, httpService)
+
+        val provider = JsonRpcProvider(legacyDevnetClient.rpcUrl, StarknetChainId.TESTNET)
+        val account = StandardAccount(legacyDevnetAddressBook.accountAddress, legacySigner, provider)
+        val balanceContractAddress = legacyDevnetAddressBook.balanceContractAddress
+
+        val nonce = account.getNonce().send()
+        val maxFee = Felt(1)
+        val call = Call(balanceContractAddress, "increase_balance", listOf(Felt(1000)))
+        val params = ExecutionParams(nonce, maxFee)
+        val invokeTx = account.sign(call, params)
+
+        val simulationFlags = setOf<SimulationFlag>()
+        val simulationResult = mockProvider.simulateTransactions(
+            transactions = listOf(invokeTx),
+            blockTag = BlockTag.LATEST,
+            simulationFlags = simulationFlags,
+        ).send()
+
+        val trace = simulationResult.first().transactionTrace
+        assertTrue(trace is InvokeTransactionTrace)
+        assertTrue(trace is RevertedInvokeTransactionTrace)
+        val revertedTrace = trace as RevertedInvokeTransactionTrace
+        assertNotNull(revertedTrace.executeInvocation)
+        assertNotNull(revertedTrace.executeInvocation?.revertReason)
     }
 }

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -823,8 +823,8 @@ class StandardAccountTest {
             simulationFlags = simulationFlags,
         ).send()
         assertEquals(2, simulationResult.size)
+        assertTrue(simulationResult[0].transactionTrace is InvokeTransactionTraceBase)
         assertTrue(simulationResult[0].transactionTrace is InvokeTransactionTrace)
-        assertTrue(simulationResult[0].transactionTrace is CommonInvokeTransactionTrace)
         assertTrue(simulationResult[1].transactionTrace is DeployAccountTransactionTrace)
 
         val invokeTxWithoutSignature = InvokeTransactionPayload(invokeTx.senderAddress, invokeTx.calldata, emptyList(), invokeTx.maxFee, invokeTx.version, invokeTx.nonce)
@@ -838,8 +838,8 @@ class StandardAccountTest {
         ).send()
 
         assertEquals(2, simulationResult2.size)
+        assertTrue(simulationResult[0].transactionTrace is InvokeTransactionTraceBase)
         assertTrue(simulationResult[0].transactionTrace is InvokeTransactionTrace)
-        assertTrue(simulationResult[0].transactionTrace is CommonInvokeTransactionTrace)
         assertTrue(simulationResult[1].transactionTrace is DeployAccountTransactionTrace)
     }
 
@@ -962,7 +962,7 @@ class StandardAccountTest {
         ).send()
 
         val trace = simulationResult.first().transactionTrace
-        assertTrue(trace is InvokeTransactionTrace)
+        assertTrue(trace is InvokeTransactionTraceBase)
         assertTrue(trace is RevertedInvokeTransactionTrace)
         val revertedTrace = trace as RevertedInvokeTransactionTrace
         assertNotNull(revertedTrace.executeInvocation)


### PR DESCRIPTION
## Describe your changes

<!-- A brief description of the changes introduced in this PR -->
- [x] #323 
- [x] #314

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #323 
Closes #314 

## Breaking changes

- [x] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
- `InvokeTransactionTrace` is renamed to `InvokeTransactionTraceBase` with derived `RevertedInvokeTransactionTrace` and `InvokeTransactionTrace`.
  - `InvokeTransactionTraceBase` currently  not have `executeInvocation` anymore.
  - Instead, `InvokeTransactionTrace` has `executeInvocation` of type `FunctionInvocation`
  - And `RevertedInvokeTransactionTrace` has `executeInvocation` of type `RevertedFunctionInvocation`