### PR TITLE
Account: Fix estimateFee; Add estimateFee and getNonce with BlockTag param

### DIFF
--- a/lib/src/main/kotlin/com/swmansion/starknet/account/Account.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/account/Account.kt
@@ -227,9 +227,21 @@ interface Account {
     /**
      * Get account nonce.
      *
-     * Get account nonce for latest state.
+     * Get account nonce for pending block.
      *
      * @return nonce as field value.
      */
     fun getNonce(): Request<Felt>
+
+    /**
+     * Get account nonce.
+     *
+     * Get account nonce for specified block tag.
+     *
+     * @param blockTag block tag used for returning this value.
+     * @return nonce as field value.
+     */
+    fun getNonce(blockTag: BlockTag): Request<Felt>
+
+    // TODO: (#326) add getNonce for block hash and block number once feeder_gateway is removed and only JsonRpcProvider is supported by StandardAccount
 }

--- a/lib/src/main/kotlin/com/swmansion/starknet/account/Account.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/account/Account.kt
@@ -225,6 +225,17 @@ interface Account {
     fun estimateFee(calls: List<Call>): Request<List<EstimateFeeResponse>>
 
     /**
+     * Estimate fee for a list of calls.
+     *
+     * Estimate fee for a signed list of calls on starknet.
+     *
+     * @param calls a list of calls used to estimate a fee.
+     * @param blockTag a tag of the block in respect to what the query will be made.
+     * @return estimated fee as field value.
+     */
+    fun estimateFee(calls: List<Call>, blockTag: BlockTag): Request<List<EstimateFeeResponse>>
+
+    /**
      * Get account nonce.
      *
      * Get account nonce for pending block.

--- a/lib/src/main/kotlin/com/swmansion/starknet/account/Account.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/account/Account.kt
@@ -215,6 +215,19 @@ interface Account {
     }
 
     /**
+     * Estimate fee for a call.
+     *
+     * Estimate fee for a signed call on starknet for specified block tag.
+     *
+     * @param call a call used to estimate a fee.
+     * @param blockTag a tag of the block in respect to what the query will be made.
+     * @return Field value representing estimated fee.
+     */
+    fun estimateFee(call: Call, blockTag: BlockTag): Request<List<EstimateFeeResponse>> {
+        return estimateFee(listOf(call), blockTag)
+    }
+
+    /**
      * Estimate fee for a list of calls.
      *
      * Estimate fee for a signed list of calls on starknet.

--- a/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
@@ -198,7 +198,9 @@ class StandardAccount(
         }
     }
 
-    override fun getNonce(): Request<Felt> = provider.getNonce(address, BlockTag.PENDING)
+    override fun getNonce(): Request<Felt> = getNonce(BlockTag.PENDING)
+
+    override fun getNonce(blockTag: BlockTag) = provider.getNonce(address, blockTag)
 
     override fun estimateFee(calls: List<Call>): Request<List<EstimateFeeResponse>> {
         return getNonce().compose { buildEstimateFeeRequest(calls, it) }


### PR DESCRIPTION
## Describe your changes

<!-- A brief description of the changes introduced in this PR -->
-  Fix `estimateFee`:  Always use `PENDING` block tag in `estimateFee(List<Call>)`
- Add `estimateFee` methods with `BlockTag` param
- Add `getNonce` method with `BlockTag` param

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #322 

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
