### PR TITLE
Bump kotlin-stdlib-jdk8 to 1.9.20; Bump version to 0.8.1

### DIFF
--- a/androiddemo/build.gradle.kts
+++ b/androiddemo/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
     implementation("com.google.android.material:material:1.9.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     // Make sure you are using the AAR and not a JAR and include transitive dependencies
-    implementation("com.swmansion.starknet:starknet:0.8.0@aar"){
+    implementation("com.swmansion.starknet:starknet:0.8.1@aar"){
         isTransitive = true
     }
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")

--- a/javademo/build.gradle.kts
+++ b/javademo/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    implementation("com.swmansion.starknet:starknet:0.8.0")
+    implementation("com.swmansion.starknet:starknet:0.8.1")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.0")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.10.0")
 }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -8,7 +8,7 @@
 
 import org.jetbrains.dokka.gradle.DokkaTask
 
-version = "0.8.0"
+version = "0.8.1"
 group = "com.swmansion.starknet"
 
 plugins {

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -121,7 +121,7 @@ dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
 
     // Use the Kotlin JDK 8 standard library.
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.1")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.20")
 
     // Use the JUnit test library.
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.0")


### PR DESCRIPTION
## Describe your changes

<!-- A brief description of the changes introduced in this PR -->

Bump https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-stdlib-jdk8 to the latest avaliable version. `1.7.1` seems like a typo from `1.7.10` that slipped unnoticed because deps in `lib` are ignored by javademo. 

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #354 

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
