### PR TITLE
Support any data in JsonRpcError

### DIFF
--- a/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
@@ -179,7 +179,7 @@ class StandardAccount(
         if (e.message?.let { regex.containsMatchIn(it) } == true) {
             return false
         }
-        if (e.revertError?.let { regex.containsMatchIn(it) } == true) {
+        if (e.data?.let { regex.containsMatchIn(it) } == true) {
             return false
         }
         throw e

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/BlockIdSerializer.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/BlockIdSerializer.kt
@@ -18,7 +18,7 @@ internal object BlockIdSerializer : KSerializer<BlockId> {
     override fun deserialize(decoder: Decoder): BlockId {
         val value = decoder.decodeString()
 
-        if (BlockTag.values().map { it.tag }.contains(value)) {
+        if (BlockTag.entries.map { it.tag }.contains(value)) {
             val tag = BlockTag.valueOf(value)
             return BlockId.Tag(tag)
         }

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/ContractClassPolymorphicSerializer.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/ContractClassPolymorphicSerializer.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.jsonObject
 
 internal object ContractClassPolymorphicSerializer : JsonContentPolymorphicSerializer<ContractClassBase>(ContractClassBase::class) {
-    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<out ContractClassBase> {
+    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<ContractClassBase> {
         return when {
             "sierra_program" in element.jsonObject -> ContractClass.serializer()
             else -> DeprecatedContractClass.serializer()

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/DeprecatedCairoEntryPointSerializer.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/DeprecatedCairoEntryPointSerializer.kt
@@ -2,10 +2,8 @@ package com.swmansion.starknet.data.serializers
 
 import com.swmansion.starknet.data.types.DeprecatedCairoEntryPoint
 import com.swmansion.starknet.extensions.toFelt
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/DeprecatedCairoEntryPointSerializer.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/DeprecatedCairoEntryPointSerializer.kt
@@ -14,8 +14,6 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.*
 import toNumAsHex
 
-@OptIn(ExperimentalSerializationApi::class)
-@Serializer(forClass = DeprecatedCairoEntryPoint::class)
 internal object DeprecatedCairoEntryPointSerializer : KSerializer<DeprecatedCairoEntryPoint> {
     override fun deserialize(decoder: Decoder): DeprecatedCairoEntryPoint {
         val input = decoder as? JsonDecoder ?: throw SerializationException("Expected JsonInput for ${decoder::class}")

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/GetBlockWithPolymorphicSerializer.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/GetBlockWithPolymorphicSerializer.kt
@@ -12,7 +12,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.jsonObject
 
 internal object GetBlockWithTransactionsPolymorphicSerializer : JsonContentPolymorphicSerializer<GetBlockWithTransactionsResponse>(GetBlockWithTransactionsResponse::class) {
-    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<out GetBlockWithTransactionsResponse> {
+    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<GetBlockWithTransactionsResponse> {
         val isPendingBlock = listOf("block_hash", "block_number", "new_root").any { it !in element.jsonObject }
 
         return when (isPendingBlock) {
@@ -23,7 +23,7 @@ internal object GetBlockWithTransactionsPolymorphicSerializer : JsonContentPolym
 }
 
 internal object GetBlockWithTransactionHashesPolymorphicSerializer : JsonContentPolymorphicSerializer<GetBlockWithTransactionHashesResponse>(GetBlockWithTransactionHashesResponse::class) {
-    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<out GetBlockWithTransactionHashesResponse> {
+    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<GetBlockWithTransactionHashesResponse> {
         val isPendingBlock = listOf("block_hash", "block_number", "new_root").any { it !in element.jsonObject }
 
         return when (isPendingBlock) {

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/JsonRpcErrorPolymorphicSerializer.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/JsonRpcErrorPolymorphicSerializer.kt
@@ -1,0 +1,60 @@
+package com.swmansion.starknet.data.serializers
+
+import com.swmansion.starknet.provider.rpc.JsonRpcContractError
+import com.swmansion.starknet.provider.rpc.JsonRpcError
+import com.swmansion.starknet.provider.rpc.JsonRpcStandardError
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.*
+
+internal object JsonRpcErrorPolymorphicSerializer : JsonContentPolymorphicSerializer<JsonRpcError>(JsonRpcError::class) {
+    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<JsonRpcError> {
+        val jsonElement = element.jsonObject
+
+        val isContractError = "data" in jsonElement &&
+            jsonElement["data"]!! is JsonObject &&
+            "revert_error" in jsonElement["data"]!!.jsonObject &&
+            jsonElement["data"]!!.jsonObject.size == 1
+        return when {
+            isContractError -> JsonRpcContractError.serializer()
+            else -> JsonRpcStandardError.serializer()
+        }
+    }
+}
+
+internal object JsonRpcStandardErrorSerializer : KSerializer<JsonRpcStandardError> {
+    override fun deserialize(decoder: Decoder): JsonRpcStandardError {
+        val input = decoder as? JsonDecoder ?: throw SerializationException("Expected JsonInput for ${decoder::class}")
+
+        val jsonObject = input.decodeJsonElement().jsonObject
+
+        val code = jsonObject.getValue("code").jsonPrimitive.content.toInt()
+        val message = jsonObject.getValue("message").jsonPrimitive.content
+        val data = jsonObject["data"]?.let {
+            when (it) {
+                is JsonPrimitive -> it.jsonPrimitive.content
+                is JsonArray -> it.jsonArray.toString()
+                is JsonObject -> it.jsonObject.toString()
+            }
+        }
+
+        return JsonRpcStandardError(
+            code = code,
+            message = message,
+            data = data,
+        )
+    }
+
+    override val descriptor: SerialDescriptor
+        get() = PrimitiveSerialDescriptor("JsonRpcStandardError", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: JsonRpcStandardError) {
+        throw SerializationException("Class used for deserialization only.")
+    }
+}

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/StateUpdatePolymorphicSerializer.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/StateUpdatePolymorphicSerializer.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.jsonObject
 
 internal object StateUpdatePolymorphicSerializer : JsonContentPolymorphicSerializer<StateUpdate>(StateUpdate::class) {
-    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<out StateUpdate> {
+    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<StateUpdate> {
         val jsonElement = element.jsonObject
         val isPending = "block_hash" !in jsonElement
         return if (isPending) PendingStateUpdateResponse.serializer() else StateUpdateResponse.serializer()

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/SyncPolymorphicSerializer.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/SyncPolymorphicSerializer.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.json.*
 
 internal object SyncPolymorphicSerializer : JsonContentPolymorphicSerializer<Syncing>(Syncing::class) {
-    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<out Syncing> = when (element) {
+    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<Syncing> = when (element) {
         JsonPrimitive(false) -> NotSyncingTransformingSerializer
         else -> SyncingResponse.serializer()
     }

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/TransactionPayloadSerializer.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/TransactionPayloadSerializer.kt
@@ -116,7 +116,6 @@ object DeclareTransactionV2PayloadSerializer : KSerializer<DeclareTransactionV2P
     }
 }
 
-@OptIn(ExperimentalSerializationApi::class)
 object InvokeTransactionPayloadSerializer : KSerializer<InvokeTransactionPayload> {
 
     override val descriptor: SerialDescriptor

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/TransactionPolymorphicSerializer.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/TransactionPolymorphicSerializer.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.*
 
 internal object TransactionPolymorphicSerializer : JsonContentPolymorphicSerializer<Transaction>(Transaction::class) {
-    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<out Transaction> {
+    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<Transaction> {
         val jsonElement = element.jsonObject
         val typeElement = jsonElement.getOrElse("type") { throw SerializationException("Input element does not contain mandatory field 'type'") }
 
@@ -21,7 +21,7 @@ internal object TransactionPolymorphicSerializer : JsonContentPolymorphicSeriali
             TransactionType.L1_HANDLER -> L1HandlerTransaction.serializer()
         }
     }
-    private fun selectInvokeDeserializer(element: JsonElement): DeserializationStrategy<out InvokeTransaction> {
+    private fun selectInvokeDeserializer(element: JsonElement): DeserializationStrategy<InvokeTransaction> {
         val jsonElement = element.jsonObject
         val versionElement = jsonElement.getOrElse("version") { throw SerializationException("Input element does not contain mandatory field 'version'") }
 
@@ -33,7 +33,7 @@ internal object TransactionPolymorphicSerializer : JsonContentPolymorphicSeriali
         }
     }
 
-    private fun selectDeclareDeserializer(element: JsonElement): DeserializationStrategy<out DeclareTransaction> {
+    private fun selectDeclareDeserializer(element: JsonElement): DeserializationStrategy<DeclareTransaction> {
         val jsonElement = element.jsonObject
         val versionElement = jsonElement.getOrElse("version") { throw SerializationException("Input element does not contain mandatory field 'version'") }
 

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/TransactionTracePolymorphicSerializer.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/TransactionTracePolymorphicSerializer.kt
@@ -8,7 +8,7 @@ import java.lang.IllegalArgumentException
 
 internal object TransactionTracePolymorphicSerializer :
     JsonContentPolymorphicSerializer<TransactionTrace>(TransactionTrace::class) {
-    private fun selectInvokeTransactionTraceDeserializer(jsonObject: JsonObject): DeserializationStrategy<out InvokeTransactionTraceBase> {
+    private fun selectInvokeTransactionTraceDeserializer(jsonObject: JsonObject): DeserializationStrategy<InvokeTransactionTraceBase> {
         val executeInvocation = jsonObject["execute_invocation"]?.jsonObject ?: throw IllegalStateException("Response from node contains invalid INVOKE_TXN_TRACE: execute_invocation is missing.")
         val isReverted = "revert_reason" in executeInvocation
 
@@ -18,7 +18,7 @@ internal object TransactionTracePolymorphicSerializer :
         }
     }
 
-    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<out TransactionTrace> {
+    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<TransactionTrace> {
         val jsonObject = element.jsonObject
 
         val typeElement = jsonObject.getOrElse("type") { throw SerializationException("Input element does not contain mandatory field 'type'") }

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/TypedDataTypeBaseSerializer.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/TypedDataTypeBaseSerializer.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.json.*
 
 internal object TypedDataTypeBaseSerializer : JsonContentPolymorphicSerializer<TypeBase>(TypeBase::class) {
-    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<out TypeBase> {
+    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<TypeBase> {
         val type = element.jsonObject["type"]?.jsonPrimitive?.content
 
         return when (type) {

--- a/lib/src/main/kotlin/com/swmansion/starknet/provider/exceptions/RequestFailedException.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/provider/exceptions/RequestFailedException.kt
@@ -5,13 +5,13 @@ package com.swmansion.starknet.provider.exceptions
  *
  * @param message error message
  * @param payload payload returned by the service used to communicate with Starknet
- * @param revertError revert error returned by the rpc provider
+ * @param data data returned by the rpc provider
  */
-open class RequestFailedException(message: String = "Request failed", val revertError: String? = null, val payload: String) : RuntimeException(message) {
+open class RequestFailedException(message: String = "Request failed", val data: String? = null, val payload: String) : RuntimeException(message) {
     override fun toString(): String {
-        return when (revertError) {
+        return when (data) {
             null -> "$message: $payload"
-            else -> "$message: $revertError : $payload"
+            else -> "$message: $data : $payload"
         }
     }
 }

--- a/lib/src/main/kotlin/com/swmansion/starknet/provider/exceptions/RpcRequestFailedException.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/provider/exceptions/RpcRequestFailedException.kt
@@ -6,7 +6,7 @@ package com.swmansion.starknet.provider.exceptions
  * @param code error code returned by the rpc provider
  * @param message error message returned by the rpc provider
  * @param payload payload returned by the service used to communicate with Starknet
- * @param revertError revert error returned by the rpc provider
+ * @param data data returned by the rpc provider
  */
-class RpcRequestFailedException(val code: Int, message: String, revertError: String? = null, payload: String) :
-    RequestFailedException(message = message, revertError = revertError, payload = payload)
+class RpcRequestFailedException(val code: Int, message: String, data: String? = null, payload: String) :
+    RequestFailedException(message = message, data = data, payload = payload)


### PR DESCRIPTION
## Describe your changes

Until RPC 0.7.0 comes out, with, hopefully, limitations on internal errors, should accept any data as an error.

<!-- A brief description of the changes introduced in this PR -->
- Separate `JsonRpcError` into `JsonRpcStandardError` and `JsonRpcContractError`
- Add tests

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #362 

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
