### PR TITLE
Make MerkleTree.hash public; Bump version to 0.8.2

### DIFF
--- a/androiddemo/build.gradle.kts
+++ b/androiddemo/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
     implementation("com.google.android.material:material:1.9.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     // Make sure you are using the AAR and not a JAR and include transitive dependencies
-    implementation("com.swmansion.starknet:starknet:0.8.1@aar"){
+    implementation("com.swmansion.starknet:starknet:0.8.2@aar"){
         isTransitive = true
     }
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")

--- a/javademo/build.gradle.kts
+++ b/javademo/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    implementation("com.swmansion.starknet:starknet:0.8.1")
+    implementation("com.swmansion.starknet:starknet:0.8.2")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.0")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.10.0")
 }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -8,7 +8,7 @@
 
 import org.jetbrains.dokka.gradle.DokkaTask
 
-version = "0.8.1"
+version = "0.8.2"
 group = "com.swmansion.starknet"
 
 plugins {

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/MerkleTree.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/MerkleTree.kt
@@ -12,7 +12,7 @@ data class MerkleTree(
 
     companion object {
         @JvmStatic
-        internal fun hash(a: Felt, b: Felt): Felt {
+        fun hash(a: Felt, b: Felt): Felt {
             val (aSorted, bSorted) = if (a < b) Pair(a, b) else Pair(b, a)
             return StarknetCurve.pedersen(aSorted, bSorted)
         }


### PR DESCRIPTION
## Describe your changes

<!-- A brief description of the changes introduced in this PR -->
- Bump version to 0.8.2
- Make `MerkleTree.hash` public to allow users to manually calculate hashes and implement functions that rely on them

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
