### PR TITLE
Bump deps

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -132,9 +132,9 @@ dependencies {
 
     // Crypto provider
     // https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk18on
-    implementation("org.bouncycastle:bcprov-jdk18on:1.76")
+    implementation("org.bouncycastle:bcprov-jdk18on:1.77")
 
-    implementation("com.squareup.okhttp3:okhttp:4.11.0")
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
 
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1")
 }


### PR DESCRIPTION
## Describe your changes

<!-- A brief description of the changes introduced in this PR -->
- Bumped `com.squareup.okhttp3:okhttp` to `4.12.0`
- Bumped `org.bouncycastle:bcprov-jdk18on` to `1.77`

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #391 

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
