### PR TITLE
Fix #400

### DIFF
--- a/lib/src/test/kotlin/network/account/AccountTest.kt
+++ b/lib/src/test/kotlin/network/account/AccountTest.kt
@@ -145,11 +145,10 @@ class AccountTest {
 
         val account = constNonceAccount
 
-        ScarbClient.createSaltedContract(
+        ScarbClient.buildSaltedContract(
             placeholderContractPath = Path.of("src/test/resources/contracts_v1/src/placeholder_hello_starknet.cairo"),
             saltedContractPath = Path.of("src/test/resources/contracts_v1/src/salted_hello_starknet.cairo"),
         )
-        ScarbClient.buildContracts(Path.of("src/test/resources/contracts_v1"))
         val contractCode = Path.of("src/test/resources/contracts_v1/target/release/ContractsV1_SaltedHelloStarknet.sierra.json").readText()
         val casmCode = Path.of("src/test/resources/contracts_v1/target/release/ContractsV1_SaltedHelloStarknet.casm.json").readText()
 
@@ -191,11 +190,10 @@ class AccountTest {
 
         val account = constNonceAccount
 
-        ScarbClient.createSaltedContract(
+        ScarbClient.buildSaltedContract(
             placeholderContractPath = Path.of("src/test/resources/contracts_v2/src/placeholder_counter_contract.cairo"),
             saltedContractPath = Path.of("src/test/resources/contracts_v2/src/salted_counter_contract.cairo"),
         )
-        ScarbClient.buildContracts(Path.of("src/test/resources/contracts_v2"))
         val contractCode = Path.of("src/test/resources/contracts_v2/target/release/ContractsV2_SaltedCounterContract.sierra.json").readText()
         val casmCode = Path.of("src/test/resources/contracts_v2/target/release/ContractsV2_SaltedCounterContract.casm.json").readText()
 
@@ -267,11 +265,10 @@ class AccountTest {
 
         val account = standardAccount
 
-        ScarbClient.createSaltedContract(
+        ScarbClient.buildSaltedContract(
             placeholderContractPath = Path.of("src/test/resources/contracts_v1/src/placeholder_hello_starknet.cairo"),
             saltedContractPath = Path.of("src/test/resources/contracts_v1/src/salted_hello_starknet.cairo"),
         )
-        ScarbClient.buildContracts(Path.of("src/test/resources/contracts_v1"))
         val contractCode = Path.of("src/test/resources/contracts_v1/target/release/ContractsV1_SaltedHelloStarknet.sierra.json").readText()
         val casmCode = Path.of("src/test/resources/contracts_v1/target/release/ContractsV1_SaltedHelloStarknet.casm.json").readText()
 
@@ -301,11 +298,10 @@ class AccountTest {
 
         val account = standardAccount
 
-        ScarbClient.createSaltedContract(
+        ScarbClient.buildSaltedContract(
             placeholderContractPath = Path.of("src/test/resources/contracts_v2/src/placeholder_counter_contract.cairo"),
             saltedContractPath = Path.of("src/test/resources/contracts_v2/src/salted_counter_contract.cairo"),
         )
-        ScarbClient.buildContracts(Path.of("src/test/resources/contracts_v2"))
         val contractCode = Path.of("src/test/resources/contracts_v2/target/release/ContractsV2_SaltedCounterContract.sierra.json").readText()
         val casmCode = Path.of("src/test/resources/contracts_v2/target/release/ContractsV2_SaltedCounterContract.casm.json").readText()
 
@@ -338,11 +334,10 @@ class AccountTest {
 
         val account = standardAccount
 
-        ScarbClient.createSaltedContract(
+        ScarbClient.buildSaltedContract(
             placeholderContractPath = Path.of("src/test/resources/contracts_v2/src/placeholder_counter_contract.cairo"),
             saltedContractPath = Path.of("src/test/resources/contracts_v2/src/salted_counter_contract.cairo"),
         )
-        ScarbClient.buildContracts(Path.of("src/test/resources/contracts_v2"))
         val contractCode = Path.of("src/test/resources/contracts_v2/target/release/ContractsV2_SaltedCounterContract.sierra.json").readText()
         val casmCode = Path.of("src/test/resources/contracts_v2/target/release/ContractsV2_SaltedCounterContract.casm.json").readText()
 
@@ -843,11 +838,10 @@ class AccountTest {
 
         val account = constNonceAccount
 
-        ScarbClient.createSaltedContract(
+        ScarbClient.buildSaltedContract(
             placeholderContractPath = Path.of("src/test/resources/contracts_v1/src/placeholder_hello_starknet.cairo"),
             saltedContractPath = Path.of("src/test/resources/contracts_v1/src/salted_hello_starknet.cairo"),
         )
-        ScarbClient.buildContracts(Path.of("src/test/resources/contracts_v1"))
         val contractCode = Path.of("src/test/resources/contracts_v1/target/release/ContractsV1_SaltedHelloStarknet.sierra.json").readText()
         val casmCode = Path.of("src/test/resources/contracts_v1/target/release/ContractsV1_SaltedHelloStarknet.casm.json").readText()
 

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -370,11 +370,10 @@ class StandardAccountTest {
 
     @Test
     fun `sign and send declare v3 transaction`() {
-        ScarbClient.createSaltedContract(
+        ScarbClient.buildSaltedContract(
             placeholderContractPath = Path.of("src/test/resources/contracts_v2/src/placeholder_counter_contract.cairo"),
             saltedContractPath = Path.of("src/test/resources/contracts_v2/src/salted_counter_contract.cairo"),
         )
-        ScarbClient.buildContracts(Path.of("src/test/resources/contracts_v2"))
         val contractCode = Path.of("src/test/resources/contracts_v2/target/release/ContractsV2_SaltedCounterContract.sierra.json").readText()
         val casmCode = Path.of("src/test/resources/contracts_v2/target/release/ContractsV2_SaltedCounterContract.casm.json").readText()
 
@@ -1083,11 +1082,10 @@ class StandardAccountTest {
 
     @Test
     fun `simulate declare v2 transaction`() {
-        ScarbClient.createSaltedContract(
+        ScarbClient.buildSaltedContract(
             placeholderContractPath = Path.of("src/test/resources/contracts_v1/src/placeholder_hello_starknet.cairo"),
             saltedContractPath = Path.of("src/test/resources/contracts_v1/src/salted_hello_starknet.cairo"),
         )
-        ScarbClient.buildContracts(Path.of("src/test/resources/contracts_v1"))
         val contractCode = Path.of("src/test/resources/contracts_v1/target/release/ContractsV1_SaltedHelloStarknet.sierra.json").readText()
         val casmCode = Path.of("src/test/resources/contracts_v1/target/release/ContractsV1_SaltedHelloStarknet.casm.json").readText()
 

--- a/lib/src/test/kotlin/starknet/utils/ScarbClient.kt
+++ b/lib/src/test/kotlin/starknet/utils/ScarbClient.kt
@@ -62,18 +62,31 @@ class ScarbClient {
         }
 
         @JvmStatic
-        fun createSaltedContract(
+        @Synchronized
+        fun buildSaltedContract(
             placeholderContractPath: Path,
             saltedContractPath: Path,
             placeholderText: String = "__placeholder__",
             saltText: String = "t${System.currentTimeMillis()}",
         ) {
+            val originalCode = saltedContractPath.readText()
+
+            createSaltedContract(
+                placeholderContractPath = placeholderContractPath,
+                saltedContractPath = saltedContractPath,
+                placeholderText = placeholderText,
+                saltText = saltText,
+            )
+            buildContracts(saltedContractPath.parent)
+
+            saltedContractPath.writeText(originalCode)
+        }
+
+        @JvmStatic
+        private fun createSaltedContract(placeholderContractPath: Path, saltedContractPath: Path, placeholderText: String, saltText: String) {
             val contractCode = placeholderContractPath.readText()
             val newContractCode = contractCode.replace(placeholderText, saltText)
-            if (saltedContractPath.toFile().exists()) {
-                saltedContractPath.toFile().delete()
-            }
-            saltedContractPath.toFile().createNewFile()
+
             saltedContractPath.writeText(newContractCode)
         }
 


### PR DESCRIPTION
## Describe your changes

<!-- A brief description of the changes introduced in this PR -->

Cherry-picked from #381 to not further clutter diff

- Add  `@Synchronized` `ScarbClient.buildSaltedContract`
  - Reset contract source after artifacts are produced by `scarb build`
- Make `ScarbClient.createSaltedContract` private
- Adjust usages
  
## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #400 

## Breaking changes

- [x] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
