### PR TITLE
Add `TransactionVersion` enum

### DIFF
--- a/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
@@ -48,10 +48,7 @@ class StandardAccount(
 
     override fun signV1(calls: List<Call>, params: ExecutionParams, forFeeEstimate: Boolean): InvokeTransactionV1Payload {
         val calldata = AccountCalldataTransformer.callsToExecuteCalldata(calls, cairoVersion)
-        val signVersion = when (forFeeEstimate) {
-            true -> estimateVersion(Felt.ONE)
-            false -> Felt.ONE
-        }
+        val signVersion = if (forFeeEstimate) TransactionVersion.V1_QUERY else TransactionVersion.V1
         val tx = TransactionFactory.makeInvokeV1Transaction(
             senderAddress = address,
             calldata = calldata,
@@ -68,10 +65,7 @@ class StandardAccount(
 
     override fun signV3(calls: List<Call>, params: InvokeParamsV3, forFeeEstimate: Boolean): InvokeTransactionV3Payload {
         val calldata = AccountCalldataTransformer.callsToExecuteCalldata(calls, cairoVersion)
-        val signVersion = when (forFeeEstimate) {
-            true -> estimateVersion(Felt(3))
-            false -> Felt(3)
-        }
+        val signVersion = if (forFeeEstimate) TransactionVersion.V3_QUERY else TransactionVersion.V3
         val tx = TransactionFactory.makeInvokeV3Transaction(
             senderAddress = address,
             calldata = calldata,
@@ -94,10 +88,7 @@ class StandardAccount(
         nonce: Felt,
         forFeeEstimate: Boolean,
     ): DeployAccountTransactionV1Payload {
-        val signVersion = when (forFeeEstimate) {
-            true -> estimateVersion(Felt.ONE)
-            false -> Felt.ONE
-        }
+        val signVersion = if (forFeeEstimate) TransactionVersion.V1_QUERY else TransactionVersion.V1
         val tx = TransactionFactory.makeDeployAccountV1Transaction(
             classHash = classHash,
             contractAddress = address,
@@ -120,10 +111,7 @@ class StandardAccount(
         params: DeployAccountParamsV3,
         forFeeEstimate: Boolean,
     ): DeployAccountTransactionV3Payload {
-        val signVersion = when (forFeeEstimate) {
-            true -> estimateVersion(Felt(3))
-            false -> Felt(3)
-        }
+        val signVersion = if (forFeeEstimate) TransactionVersion.V3_QUERY else TransactionVersion.V3
         val tx = TransactionFactory.makeDeployAccountV3Transaction(
             classHash = classHash,
             senderAddress = address,
@@ -145,10 +133,7 @@ class StandardAccount(
         params: ExecutionParams,
         forFeeEstimate: Boolean,
     ): DeclareTransactionV1Payload {
-        val signVersion = when (forFeeEstimate) {
-            true -> estimateVersion(Felt.ONE)
-            false -> Felt.ONE
-        }
+        val signVersion = if (forFeeEstimate) TransactionVersion.V1_QUERY else TransactionVersion.V1
         val tx = TransactionFactory.makeDeclareV1Transaction(
             contractDefinition = contractDefinition,
             classHash = classHash,
@@ -169,10 +154,7 @@ class StandardAccount(
         params: ExecutionParams,
         forFeeEstimate: Boolean,
     ): DeclareTransactionV2Payload {
-        val signVersion = when (forFeeEstimate) {
-            true -> estimateVersion(Felt(2))
-            false -> Felt(2)
-        }
+        val signVersion = if (forFeeEstimate) TransactionVersion.V2_QUERY else TransactionVersion.V2
         val tx = TransactionFactory.makeDeclareV2Transaction(
             contractDefinition = sierraContractDefinition,
             senderAddress = address,
@@ -193,10 +175,7 @@ class StandardAccount(
         params: DeclareParamsV3,
         forFeeEstimate: Boolean,
     ): DeclareTransactionV3Payload {
-        val signVersion = when (forFeeEstimate) {
-            true -> estimateVersion(Felt(3))
-            false -> Felt(3)
-        }
+        val signVersion = if (forFeeEstimate) TransactionVersion.V3_QUERY else TransactionVersion.V3
         val tx = TransactionFactory.makeDeclareV3Transaction(
             contractDefinition = sierraContractDefinition,
             senderAddress = address,

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/TransactionHashCalculator.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/TransactionHashCalculator.kt
@@ -5,6 +5,7 @@ import com.swmansion.starknet.crypto.StarknetCurve
 import com.swmansion.starknet.data.types.*
 import com.swmansion.starknet.data.types.transactions.DAMode
 import com.swmansion.starknet.data.types.transactions.TransactionType
+import com.swmansion.starknet.data.types.transactions.TransactionVersion
 import com.swmansion.starknet.extensions.toFelt
 import com.swmansion.starknet.provider.Provider
 
@@ -22,7 +23,7 @@ object TransactionHashCalculator {
         contractAddress: Felt,
         calldata: Calldata,
         chainId: Felt,
-        version: Felt,
+        version: TransactionVersion,
         nonce: Felt,
         maxFee: Felt,
     ): Felt = transactionHashCommon(
@@ -41,7 +42,7 @@ object TransactionHashCalculator {
         senderAddress: Felt,
         calldata: Calldata,
         chainId: Felt,
-        version: Felt,
+        version: TransactionVersion,
         nonce: Felt,
         tip: Uint64,
         resourceBounds: ResourceBoundsMapping,
@@ -74,7 +75,7 @@ object TransactionHashCalculator {
         calldata: Calldata,
         salt: Felt,
         chainId: Felt,
-        version: Felt,
+        version: TransactionVersion,
         maxFee: Felt,
         nonce: Felt,
     ): Felt {
@@ -102,7 +103,7 @@ object TransactionHashCalculator {
         salt: Felt,
         paymasterData: PaymasterData,
         chainId: Felt,
-        version: Felt,
+        version: TransactionVersion,
         nonce: Felt,
         tip: Uint64,
         resourceBounds: ResourceBoundsMapping,
@@ -139,13 +140,13 @@ object TransactionHashCalculator {
         chainId: Felt,
         senderAddress: Felt,
         maxFee: Felt,
-        version: Felt,
+        version: TransactionVersion,
         nonce: Felt,
     ): Felt {
         val hash = StarknetCurve.pedersenOnElements(listOf(classHash))
         return StarknetCurve.pedersenOnElements(
             TransactionType.DECLARE.txPrefix,
-            version,
+            version.value,
             senderAddress,
             Felt.ZERO,
             hash,
@@ -161,14 +162,14 @@ object TransactionHashCalculator {
         chainId: Felt,
         senderAddress: Felt,
         maxFee: Felt,
-        version: Felt,
+        version: TransactionVersion,
         nonce: Felt,
         compiledClassHash: Felt,
     ): Felt {
         val calldataHash = StarknetCurve.pedersenOnElements(listOf(classHash))
         return StarknetCurve.pedersenOnElements(
             TransactionType.DECLARE.txPrefix,
-            version,
+            version.value,
             senderAddress,
             Felt.ZERO,
             calldataHash,
@@ -184,7 +185,7 @@ object TransactionHashCalculator {
         classHash: Felt,
         chainId: Felt,
         senderAddress: Felt,
-        version: Felt,
+        version: TransactionVersion,
         nonce: Felt,
         compiledClassHash: Felt,
         tip: Uint64,
@@ -215,7 +216,7 @@ object TransactionHashCalculator {
 
     private fun transactionHashCommon(
         txType: TransactionType,
-        version: Felt,
+        version: TransactionVersion,
         contractAddress: Felt,
         entryPointSelector: Felt,
         calldata: Calldata,
@@ -225,7 +226,7 @@ object TransactionHashCalculator {
     ): Felt {
         return StarknetCurve.pedersenOnElements(
             txType.txPrefix,
-            version,
+            version.value,
             contractAddress,
             entryPointSelector,
             StarknetCurve.pedersenOnElements(calldata),
@@ -237,7 +238,7 @@ object TransactionHashCalculator {
 
     private fun prepareCommonTransanctionV3Fields(
         txType: TransactionType,
-        version: Felt,
+        version: TransactionVersion,
         address: Felt,
         tip: Uint64,
         resourceBounds: ResourceBoundsMapping,
@@ -249,7 +250,7 @@ object TransactionHashCalculator {
     ): List<Felt> {
         return listOf(
             txType.txPrefix,
-            version,
+            version.value,
             address,
             Poseidon.poseidonHash(
                 tip.toFelt,

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/TransactionPayloadSerializer.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/serializers/TransactionPayloadSerializer.kt
@@ -95,7 +95,7 @@ internal object DeclareTransactionV1PayloadSerializer : KSerializer<DeclareTrans
         val jsonObject = buildJsonObject {
             put("contract_class", value.contractDefinition.toJson())
             put("sender_address", value.senderAddress.hexString())
-            put("version", value.version)
+            put("version", value.version.value.hexString())
             put("max_fee", value.maxFee.hexString())
             putJsonArray("signature") { value.signature.forEach { add(it) } }
             put("nonce", value.nonce)
@@ -119,7 +119,7 @@ internal object DeclareTransactionV2PayloadSerializer : KSerializer<DeclareTrans
         val jsonObject = buildJsonObject {
             put("contract_class", value.contractDefinition.toJson())
             put("sender_address", value.senderAddress.hexString())
-            put("version", value.version)
+            put("version", value.version.value.hexString())
             put("max_fee", value.maxFee.hexString())
             putJsonArray("signature") { value.signature.forEach { add(it) } }
             put("nonce", value.nonce)
@@ -144,7 +144,7 @@ internal object DeclareTransactionV3PayloadSerializer : KSerializer<DeclareTrans
         val jsonObject = buildJsonObject {
             put("contract_class", value.contractDefinition.toJson())
             put("sender_address", value.senderAddress.hexString())
-            put("version", value.version)
+            put("version", value.version.value.hexString())
             putJsonArray("signature") { value.signature.forEach { add(it) } }
             put("nonce", value.nonce)
             put("type", value.type.toString())

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/Transaction.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/Transaction.kt
@@ -37,7 +37,7 @@ enum class TransactionType(val txPrefix: Felt) {
  * Standard versions include [V0], [V1], [V2], and [V3]. These are utilized for regular transaction execution.
  * Query versions [V1_QUERY], [V2_QUERY], and [V3_QUERY] should only be used for creating transactions to be used
  * in queries that do not alter the chain state, as in methods like [Provider.simulateTransactions] and [Provider.getEstimateFee].
- * Avoid using query versions for transactions intended for execution.
+ * Sending transaction with a query version for execution will result in a failure.
  */
 @Serializable
 enum class TransactionVersion(val value: Felt) {

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/Transaction.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/Transaction.kt
@@ -29,6 +29,16 @@ enum class TransactionType(val txPrefix: Felt) {
     L1_HANDLER(Felt.fromHex("0x6c315f68616e646c6572")), // encodeShortString('l1_handler')
 }
 
+/**
+ * The version of the transaction.
+ *
+ * The version is used to determine the transaction format and is used for transaction signing.
+ *
+ * Standard versions include [V0], [V1], [V2], and [V3]. These are utilized for regular transaction execution.
+ * Query versions [V1_QUERY], [V2_QUERY], and [V3_QUERY] should only be used for creating transactions to be used
+ * in queries that do not alter the chain state, as in methods like [Provider.simulateTransactions] and [Provider.getEstimateFee].
+ * Avoid using query versions for transactions intended for execution.
+ */
 @Serializable
 enum class TransactionVersion(val value: Felt) {
     @SerialName("0x0")

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/Transaction.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/Transaction.kt
@@ -30,6 +30,30 @@ enum class TransactionType(val txPrefix: Felt) {
 }
 
 @Serializable
+enum class TransactionVersion(val value: Felt) {
+    @SerialName("0x0")
+    V0(Felt.ZERO),
+
+    @SerialName("0x1")
+    V1(Felt.ONE),
+
+    @SerialName("0x100000000000000000000000000000001")
+    V1_QUERY(Felt.fromHex("0x100000000000000000000000000000001")),
+
+    @SerialName("0x2")
+    V2(Felt(2)),
+
+    @SerialName("0x100000000000000000000000000000002")
+    V2_QUERY(Felt.fromHex("0x100000000000000000000000000000002")),
+
+    @SerialName("0x3")
+    V3(Felt(3)),
+
+    @SerialName("0x100000000000000000000000000000003")
+    V3_QUERY(Felt.fromHex("0x100000000000000000000000000000003")),
+}
+
+@Serializable
 enum class DAMode(val value: Int) {
     @SerialName("L1")
     L1(0),
@@ -41,7 +65,7 @@ enum class DAMode(val value: Int) {
 @Serializable
 sealed class Transaction {
     abstract val hash: Felt?
-    abstract val version: Felt
+    abstract val version: TransactionVersion
     abstract val signature: Signature
     abstract val nonce: Felt
     abstract val type: TransactionType
@@ -50,7 +74,7 @@ sealed class Transaction {
 @Serializable
 sealed interface DeprecatedTransaction {
     @SerialName("version")
-    val version: Felt
+    val version: TransactionVersion
 
     @SerialName("signature")
     val signature: Signature
@@ -68,7 +92,7 @@ sealed interface DeprecatedTransaction {
 @Serializable
 sealed interface TransactionV3 {
     @SerialName("version")
-    val version: Felt
+    val version: TransactionVersion
 
     @SerialName("signature")
     val signature: Signature
@@ -116,7 +140,7 @@ data class DeployTransaction(
     override val maxFee: Felt = Felt.ZERO,
 
     @SerialName("version")
-    override val version: Felt,
+    override val version: TransactionVersion,
 
     // not in RPC spec
     @SerialName("signature")
@@ -152,7 +176,7 @@ data class InvokeTransactionV1(
     override val maxFee: Felt,
 
     @SerialName("version")
-    override val version: Felt = Felt.ONE,
+    override val version: TransactionVersion = TransactionVersion.V1,
 
     @SerialName("signature")
     override val signature: Signature,
@@ -186,7 +210,7 @@ data class InvokeTransactionV3(
     override val hash: Felt? = null,
 
     @SerialName("version")
-    override val version: Felt = Felt(3),
+    override val version: TransactionVersion = TransactionVersion.V3,
 
     @SerialName("signature")
     override val signature: Signature,
@@ -237,7 +261,7 @@ data class InvokeTransactionV0(
     val maxFee: Felt,
 
     @SerialName("version")
-    override val version: Felt = Felt.ZERO,
+    override val version: TransactionVersion = TransactionVersion.V0,
 
     @SerialName("signature")
     override val signature: Signature,
@@ -277,7 +301,7 @@ data class DeclareTransactionV0(
     override val maxFee: Felt,
 
     @SerialName("version")
-    override val version: Felt = Felt.ZERO,
+    override val version: TransactionVersion = TransactionVersion.V0,
 
     @SerialName("signature")
     override val signature: Signature,
@@ -305,7 +329,7 @@ data class DeclareTransactionV1(
     override val maxFee: Felt,
 
     @SerialName("version")
-    override val version: Felt = Felt.ONE,
+    override val version: TransactionVersion = TransactionVersion.V1,
 
     @SerialName("signature")
     override val signature: Signature,
@@ -349,7 +373,7 @@ data class DeclareTransactionV2(
     override val maxFee: Felt,
 
     @SerialName("version")
-    override val version: Felt = Felt(2),
+    override val version: TransactionVersion = TransactionVersion.V2,
 
     @SerialName("signature")
     override val signature: Signature,
@@ -393,7 +417,7 @@ data class DeclareTransactionV3(
     override val hash: Felt? = null,
 
     @SerialName("version")
-    override val version: Felt = Felt(3),
+    override val version: TransactionVersion = TransactionVersion.V3,
 
     @SerialName("signature")
     override val signature: Signature,
@@ -462,7 +486,7 @@ data class L1HandlerTransaction(
     override val maxFee: Felt = Felt.ZERO,
 
     @SerialName("version")
-    override val version: Felt,
+    override val version: TransactionVersion = TransactionVersion.V0,
 
     @SerialName("signature")
     override val signature: Signature = emptyList(),
@@ -516,7 +540,7 @@ data class DeployAccountTransactionV1(
     override val maxFee: Felt,
 
     @SerialName("version")
-    override val version: Felt,
+    override val version: TransactionVersion = TransactionVersion.V1,
 
     @SerialName("signature")
     override val signature: Signature,
@@ -557,7 +581,7 @@ data class DeployAccountTransactionV3(
     override val hash: Felt? = null,
 
     @SerialName("version")
-    override val version: Felt,
+    override val version: TransactionVersion = TransactionVersion.V3,
 
     @SerialName("signature")
     override val signature: Signature,
@@ -614,7 +638,7 @@ object TransactionFactory {
         nonce: Felt,
         maxFee: Felt,
         signature: Signature = emptyList(),
-        version: Felt,
+        version: TransactionVersion,
     ): InvokeTransactionV1 {
         val hash = TransactionHashCalculator.calculateInvokeTxV1Hash(
             contractAddress = senderAddress,
@@ -643,7 +667,7 @@ object TransactionFactory {
         chainId: Felt,
         nonce: Felt,
         signature: Signature = emptyList(),
-        version: Felt,
+        version: TransactionVersion,
         resourceBounds: ResourceBoundsMapping,
     ): InvokeTransactionV3 {
         val hash = TransactionHashCalculator.calculateInvokeTxV3Hash(
@@ -683,7 +707,7 @@ object TransactionFactory {
         salt: Felt,
         calldata: Calldata,
         chainId: Felt,
-        version: Felt,
+        version: TransactionVersion,
         maxFee: Felt,
         signature: Signature = emptyList(),
         nonce: Felt = Felt.ZERO,
@@ -718,7 +742,7 @@ object TransactionFactory {
         salt: Felt,
         calldata: Calldata,
         chainId: Felt,
-        version: Felt,
+        version: TransactionVersion,
         signature: Signature = emptyList(),
         nonce: Felt = Felt.ZERO,
         resourceBounds: ResourceBoundsMapping,
@@ -761,7 +785,7 @@ object TransactionFactory {
         contractDefinition: Cairo0ContractDefinition,
         chainId: Felt,
         maxFee: Felt,
-        version: Felt,
+        version: TransactionVersion,
         nonce: Felt,
         signature: Signature = emptyList(),
     ): DeclareTransactionV1 {
@@ -792,7 +816,7 @@ object TransactionFactory {
         contractDefinition: Cairo1ContractDefinition,
         chainId: Felt,
         maxFee: Felt,
-        version: Felt,
+        version: TransactionVersion,
         nonce: Felt,
         casmContractDefinition: CasmContractDefinition,
         signature: Signature = emptyList(),
@@ -827,7 +851,7 @@ object TransactionFactory {
         senderAddress: Felt,
         contractDefinition: Cairo1ContractDefinition,
         chainId: Felt,
-        version: Felt,
+        version: TransactionVersion,
         nonce: Felt,
         casmContractDefinition: CasmContractDefinition,
         signature: Signature = emptyList(),

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/TransactionPayload.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/transactions/TransactionPayload.kt
@@ -31,7 +31,7 @@ data class InvokeTransactionV1Payload(
     val maxFee: Felt,
 
     @SerialName("version")
-    val version: Felt,
+    val version: TransactionVersion,
 
     @SerialName("nonce")
     val nonce: Felt,
@@ -71,7 +71,7 @@ data class InvokeTransactionV3Payload private constructor(
     val feeDataAvailabilityMode: DAMode,
 
     @SerialName("version")
-    val version: Felt,
+    val version: TransactionVersion,
 ) : InvokeTransactionPayload() {
     constructor(
         senderAddress: Felt,
@@ -79,7 +79,7 @@ data class InvokeTransactionV3Payload private constructor(
         signature: Signature,
         nonce: Felt,
         resourceBounds: ResourceBoundsMapping,
-        version: Felt,
+        version: TransactionVersion,
     ) : this(
         senderAddress = senderAddress,
         calldata = calldata,
@@ -116,7 +116,7 @@ data class DeclareTransactionV1Payload(
     val senderAddress: Felt,
 
     @SerialName("version")
-    val version: Felt,
+    val version: TransactionVersion,
 
     @SerialName("type")
     override val type: TransactionType = TransactionType.DECLARE,
@@ -143,7 +143,7 @@ data class DeclareTransactionV2Payload(
     val compiledClassHash: Felt,
 
     @SerialName("version")
-    val version: Felt,
+    val version: TransactionVersion,
 
     @SerialName("type")
     override val type: TransactionType = TransactionType.DECLARE,
@@ -186,7 +186,7 @@ data class DeclareTransactionV3Payload private constructor(
     val feeDataAvailabilityMode: DAMode,
 
     @SerialName("version")
-    val version: Felt,
+    val version: TransactionVersion,
 
     @SerialName("type")
     override val type: TransactionType = TransactionType.DECLARE,
@@ -198,7 +198,7 @@ data class DeclareTransactionV3Payload private constructor(
         senderAddress: Felt,
         compiledClassHash: Felt,
         resourceBounds: ResourceBoundsMapping,
-        version: Felt,
+        version: TransactionVersion,
     ) : this(
         contractDefinition = contractDefinition,
         nonce = nonce,
@@ -230,7 +230,7 @@ data class DeployAccountTransactionV1Payload(
     val constructorCalldata: Calldata,
 
     @SerialName("version")
-    val version: Felt,
+    val version: TransactionVersion,
 
     @SerialName("nonce")
     val nonce: Felt,
@@ -258,7 +258,7 @@ data class DeployAccountTransactionV3Payload private constructor(
     val constructorCalldata: Calldata,
 
     @SerialName("version")
-    val version: Felt,
+    val version: TransactionVersion,
 
     @SerialName("nonce")
     val nonce: Felt,
@@ -288,7 +288,7 @@ data class DeployAccountTransactionV3Payload private constructor(
         classHash: Felt,
         salt: Felt,
         constructorCalldata: Calldata,
-        version: Felt,
+        version: TransactionVersion,
         nonce: Felt,
         signature: Signature,
         resourceBounds: ResourceBoundsMapping,

--- a/lib/src/test/kotlin/com/swmansion/starknet/data/TransactionHashCalculatorTest.kt
+++ b/lib/src/test/kotlin/com/swmansion/starknet/data/TransactionHashCalculatorTest.kt
@@ -2,6 +2,7 @@ package com.swmansion.starknet.data
 
 import com.swmansion.starknet.data.types.*
 import com.swmansion.starknet.data.types.transactions.DAMode
+import com.swmansion.starknet.data.types.transactions.TransactionVersion
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -19,7 +20,7 @@ internal class TransactionHashCalculatorTest {
                 contractAddress = Felt.fromHex("0x6352037a8acbb31095a8ed0f4aa8d8639e13b705b043a1b08f9640d2f9f0d56"),
                 calldata = calldata,
                 chainId = chainId,
-                version = Felt.ONE,
+                version = TransactionVersion.V1,
                 nonce = Felt(9876),
                 maxFee = maxFee,
             )
@@ -34,7 +35,7 @@ internal class TransactionHashCalculatorTest {
                 calldata = calldata,
                 salt = Felt(1234),
                 chainId = chainId,
-                version = Felt.ONE,
+                version = TransactionVersion.V1,
                 maxFee = maxFee,
                 nonce = Felt.ZERO,
             )
@@ -47,7 +48,7 @@ internal class TransactionHashCalculatorTest {
             val hash = TransactionHashCalculator.calculateDeclareV1TxHash(
                 classHash = Felt.fromHex("0x5ae9d09292a50ed48c5930904c880dab56e85b825022a7d689cfc9e65e01ee7"),
                 senderAddress = Felt.fromHex("0x6352037a8acbb31095a8ed0f4aa8d8639e13b705b043a1b08f9640d2f9f0d56"),
-                version = Felt.ONE,
+                version = TransactionVersion.V1,
                 chainId = chainId,
                 nonce = Felt(9876),
                 maxFee = maxFee,
@@ -62,7 +63,7 @@ internal class TransactionHashCalculatorTest {
                 classHash = Felt.fromHex("0x5ae9d09292a50ed48c5930904c880dab56e85b825022a7d689cfc9e65e01ee7"),
                 compiledClassHash = Felt.fromHex("0x1add56d64bebf8140f3b8a38bdf102b7874437f0c861ab4ca7526ec33b4d0f8"),
                 senderAddress = Felt.fromHex("0x6352037a8acbb31095a8ed0f4aa8d8639e13b705b043a1b08f9640d2f9f0d56"),
-                version = Felt(2),
+                version = TransactionVersion.V2,
                 chainId = chainId,
                 nonce = Felt(9876),
                 maxFee = maxFee,
@@ -126,7 +127,7 @@ internal class TransactionHashCalculatorTest {
                     Felt.fromHex("0x613816405e6334ab420e53d4b38a0451cb2ebca2755171315958c87d303cf6"),
                 ),
                 chainId = chainId,
-                version = Felt(3),
+                version = TransactionVersion.V3,
                 nonce = Felt.fromHex("0x8a9"),
                 accountDeploymentData = emptyList(),
                 tip = Uint64.ZERO,
@@ -153,7 +154,7 @@ internal class TransactionHashCalculatorTest {
                 classHash = Felt.fromHex("0x2338634f11772ea342365abd5be9d9dc8a6f44f159ad782fdebd3db5d969738"),
                 salt = Felt.ZERO,
                 chainId = chainId,
-                version = Felt(3),
+                version = TransactionVersion.V3,
                 nonce = Felt.ZERO,
                 resourceBounds = ResourceBoundsMapping(
                     l1Gas = ResourceBounds(
@@ -176,7 +177,7 @@ internal class TransactionHashCalculatorTest {
                 classHash = Felt.fromHex("0x5ae9d09292a50ed48c5930904c880dab56e85b825022a7d689cfc9e65e01ee7"),
                 compiledClassHash = Felt.fromHex("0x1add56d64bebf8140f3b8a38bdf102b7874437f0c861ab4ca7526ec33b4d0f8"),
                 senderAddress = Felt.fromHex("0x2fab82e4aef1d8664874e1f194951856d48463c3e6bf9a8c68e234a629a6f50"),
-                version = Felt(3),
+                version = TransactionVersion.V3,
                 chainId = chainId,
                 nonce = Felt.ONE,
                 resourceBounds = ResourceBoundsMapping(

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -174,8 +174,8 @@ class StandardAccountTest {
                 params = InvokeParamsV3(nonce.value.add(BigInteger.ONE).toFelt, ResourceBounds.ZERO),
                 forFeeEstimate = true,
             )
-            assertEquals(Felt.fromHex("0x100000000000000000000000000000001"), invokeTxV1Payload.version)
-            assertEquals(Felt.fromHex("0x100000000000000000000000000000003"), invokeTxV3Payload.version)
+            assertEquals(Felt.fromHex("0x100000000000000000000000000000001"), invokeTxV1Payload.version.value)
+            assertEquals(Felt.fromHex("0x100000000000000000000000000000003"), invokeTxV3Payload.version.value)
 
             val invokeTxV1PayloadWithoutSignature = invokeTxV1Payload.copy(signature = emptyList())
             val invokeTxV3PayloadWithoutSignature = invokeTxV3Payload.copy(signature = emptyList())
@@ -223,7 +223,7 @@ class StandardAccountTest {
                 forFeeEstimate = true,
             )
 
-            assertEquals(Felt.fromHex("0x100000000000000000000000000000001"), declareTransactionPayload.version)
+            assertEquals(Felt.fromHex("0x100000000000000000000000000000001"), declareTransactionPayload.version.value)
 
             val request = provider.getEstimateFee(payload = listOf(declareTransactionPayload), simulationFlags = emptySet())
             val feeEstimate = request.send().first()
@@ -248,7 +248,7 @@ class StandardAccountTest {
                 forFeeEstimate = true,
             )
 
-            assertEquals(Felt.fromHex("0x100000000000000000000000000000002"), declareTransactionPayload.version)
+            assertEquals(Felt.fromHex("0x100000000000000000000000000000002"), declareTransactionPayload.version.value)
 
             val request = provider.getEstimateFee(payload = listOf(declareTransactionPayload), simulationFlags = emptySet())
             val feeEstimate = request.send().first()
@@ -273,7 +273,7 @@ class StandardAccountTest {
                 true,
             )
 
-            assertEquals(Felt.fromHex("0x100000000000000000000000000000003"), declareTransactionPayload.version)
+            assertEquals(Felt.fromHex("0x100000000000000000000000000000003"), declareTransactionPayload.version.value)
 
             val request = provider.getEstimateFee(payload = listOf(declareTransactionPayload), simulationFlags = emptySet())
             val feeEstimate = request.send().first()
@@ -816,7 +816,7 @@ class StandardAccountTest {
                 nonce = Felt.ZERO,
                 forFeeEstimate = true,
             )
-            assertEquals(Felt.fromHex("0x100000000000000000000000000000001"), payloadForFeeEstimation.version)
+            assertEquals(Felt.fromHex("0x100000000000000000000000000000001"), payloadForFeeEstimation.version.value)
 
             val feePayload = provider.getEstimateFee(listOf(payloadForFeeEstimation)).send()
             assertTrue(feePayload.first().overallFee.value > Felt.ONE.value)
@@ -851,7 +851,7 @@ class StandardAccountTest {
                 forFeeEstimate = true,
             )
 
-            assertEquals(Felt.fromHex("0x100000000000000000000000000000003"), payloadForFeeEstimation.version)
+            assertEquals(Felt.fromHex("0x100000000000000000000000000000003"), payloadForFeeEstimation.version.value)
 
             val feePayload = provider.getEstimateFee(listOf(payloadForFeeEstimation)).send()
             assertTrue(feePayload.first().overallFee.value > Felt.ONE.value)
@@ -999,7 +999,7 @@ class StandardAccountTest {
             nonce = Felt.ONE,
             forFeeEstimate = true,
         )
-        assertEquals(Felt.fromHex("0x100000000000000000000000000000001"), payloadForFeeEstimation.version)
+        assertEquals(Felt.fromHex("0x100000000000000000000000000000001"), payloadForFeeEstimation.version.value)
 
         assertThrows(RequestFailedException::class.java) {
             provider.deployAccount(payloadForFeeEstimation).send()

--- a/lib/src/test/kotlin/starknet/data/types/TransactionsTest.kt
+++ b/lib/src/test/kotlin/starknet/data/types/TransactionsTest.kt
@@ -21,7 +21,7 @@ internal class TransactionsTest {
             chainId = chainId,
             nonce = Felt.ZERO,
             maxFee = Felt.ZERO,
-            version = Felt.ONE,
+            version = TransactionVersion.V1,
         )
 
         assertEquals(Felt.fromHex("0x22294fe217f962c39e4cb694a5db3f71e1132988451a9b2abc2d2ea8512088e"), tx1.hash)
@@ -51,7 +51,7 @@ internal class TransactionsTest {
             chainId = chainId,
             nonce = Felt.ZERO,
             maxFee = Felt(BigInteger("100000000")),
-            version = Felt.ONE,
+            version = TransactionVersion.V1,
         )
 
         assertEquals(Felt.fromHex("0xff63c84949d3ab0ced753c227528493dea3dc4680c65c1facb7f86ae0472df"), tx2.hash)


### PR DESCRIPTION
## Describe your changes

<!-- A brief description of the changes introduced in this PR -->

Related to #409

- Add `TransactionVersion` enum
- Use it instead of `Felt` in tx, tx payload dataclasses and related functions

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #412 

## Breaking changes

- [x] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->

- `version` argument in `TransactionFactory` functions is now of type `TransactionVersion` instead of `Felt`
- `version` argument in `TransactionHashCalculator` functions is now of type `TransactionVersion` instead of `Felt`
- `TransactionPayload.version` is now of type `TransactionVersion` instead of `Felt`
