### PR TITLE
Add ByteArray

### DIFF
--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/StarknetByteArray.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/StarknetByteArray.kt
@@ -18,12 +18,10 @@ data class StarknetByteArray(
             val shortStrings = string.splitToShortStrings()
             val encodedShortStrings = shortStrings.map(Felt::fromShortString)
 
-            val (data, pendingWord, pendingWordLen) = if (shortStrings.isEmpty() || shortStrings.last().length == 31)
-                Triple(encodedShortStrings, Felt.ZERO, 0)
+            return if (shortStrings.isEmpty() || shortStrings.last().length == 31)
+                StarknetByteArray(encodedShortStrings, Felt.ZERO, 0)
             else
-                Triple(encodedShortStrings.dropLast(1), encodedShortStrings.last(), shortStrings.last().length)
-
-            return StarknetByteArray(data.ifEmpty { listOf(Felt.ZERO) }, pendingWord, pendingWordLen)
+                StarknetByteArray(encodedShortStrings.dropLast(1), encodedShortStrings.last(), shortStrings.last().length)
         }
     }
 }

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/StarknetByteArray.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/StarknetByteArray.kt
@@ -4,16 +4,33 @@ import com.swmansion.starknet.data.types.conversions.ConvertibleToCalldata
 import com.swmansion.starknet.extensions.splitToShortStrings
 import com.swmansion.starknet.extensions.toFelt
 
+/**
+ * Represents a ByteArray struct from Cairo.
+ *
+ * The ByteArray struct is used to represent a string in Cairo.
+ *
+ * @param data The list of 31-byte chunks of the byte array
+ * @param pendingWord The last chunk of the byte array, which consists of at most 30 bytes
+ * @param pendingWordLen The number of bytes in [pendingWord]
+ */
 data class StarknetByteArray(
     val data: List<Felt>,
     val pendingWord: Felt,
     val pendingWordLen: Int,
 ) : ConvertibleToCalldata {
+    /**
+     * Encode as a Felt list
+     */
     override fun toCalldata(): List<Felt> {
         return listOf(data.size.toFelt) + data + listOf(pendingWord, pendingWordLen.toFelt)
     }
 
     companion object {
+        /**
+         * Create byte array from a string.
+         *
+         * @param string The string to be transformed to byte array
+         */
         @JvmStatic
         fun fromString(string: String): StarknetByteArray {
             val shortStrings = string.splitToShortStrings()

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/StarknetByteArray.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/StarknetByteArray.kt
@@ -19,8 +19,8 @@ data class StarknetByteArray(
     val pendingWordLen: Int,
 ) : ConvertibleToCalldata {
     init {
-        data.forEach{
-            require(it.byteLength == 31) { "All elements of 'data' must be 31 bytes long. [${it.hexString()}] of length [${it.byteLength}] given."}
+        data.forEach {
+            require(it.byteLength == 31) { "All elements of 'data' must be 31 bytes long. [${it.hexString()}] of length [${it.byteLength}] given." }
         }
         require(pendingWordLen in 0..30) {
             "The length of 'pendingWord' must be between 0 and 30. [$pendingWordLen] given."

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/StarknetByteArray.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/StarknetByteArray.kt
@@ -14,6 +14,7 @@ data class StarknetByteArray(
     }
 
     companion object {
+        @JvmStatic
         fun fromString(string: String): StarknetByteArray {
             val shortStrings = string.splitToShortStrings()
             val encodedShortStrings = shortStrings.map(Felt::fromShortString)

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/StarknetByteArray.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/StarknetByteArray.kt
@@ -18,6 +18,18 @@ data class StarknetByteArray(
     val pendingWord: Felt,
     val pendingWordLen: Int,
 ) : ConvertibleToCalldata {
+    init {
+        data.forEach{
+            require(it.byteLength == 31) { "All elements of 'data' must be 31 bytes long. [${it.hexString()}] of length [${it.byteLength}] given."}
+        }
+        require(pendingWordLen in 0..30) {
+            "The length of 'pendingWord' must be between 0 and 30. [$pendingWordLen] given."
+        }
+        require(pendingWord.byteLength == pendingWordLen) {
+            "The length of 'pendingWord' must be equal to 'pendingWordLen'. [${pendingWord.hexString()}] of length [${pendingWord.byteLength}] given."
+        }
+    }
+
     /**
      * Encode as a Felt list
      */
@@ -43,3 +55,6 @@ data class StarknetByteArray(
         }
     }
 }
+
+internal val Felt.byteLength: Int
+    get() = (value.bitLength() + 7) / 8

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/StarknetByteArray.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/StarknetByteArray.kt
@@ -1,0 +1,27 @@
+package com.swmansion.starknet.data.types
+
+import com.swmansion.starknet.data.types.conversions.ConvertibleToCalldata
+import com.swmansion.starknet.extensions.splitToShortStrings
+import com.swmansion.starknet.extensions.toFelt
+
+data class StarknetByteArray(
+    val data: List<Felt>,
+    val pendingWord: Felt,
+    val pendingWordLen: Int,
+) : ConvertibleToCalldata {
+    override fun toCalldata(): List<Felt> {
+        return listOf(data.size.toFelt) + data + listOf(pendingWord, pendingWordLen.toFelt)
+    }
+
+    companion object {
+        fun fromString(string: String): StarknetByteArray {
+            val shortStrings = string.splitToShortStrings()
+            val encodedShortStrings = shortStrings.map(Felt::fromShortString)
+
+            return if (shortStrings.isEmpty() || shortStrings.last().length == 31)
+                StarknetByteArray(encodedShortStrings, Felt.ZERO, 0)
+            else
+                StarknetByteArray(encodedShortStrings.dropLast(1), encodedShortStrings.last(), shortStrings.last().length)
+        }
+    }
+}

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/StarknetByteArray.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/StarknetByteArray.kt
@@ -18,10 +18,12 @@ data class StarknetByteArray(
             val shortStrings = string.splitToShortStrings()
             val encodedShortStrings = shortStrings.map(Felt::fromShortString)
 
-            return if (shortStrings.isEmpty() || shortStrings.last().length == 31)
-                StarknetByteArray(encodedShortStrings, Felt.ZERO, 0)
+            val (data, pendingWord, pendingWordLen) = if (shortStrings.isEmpty() || shortStrings.last().length == 31)
+                Triple(encodedShortStrings, Felt.ZERO, 0)
             else
-                StarknetByteArray(encodedShortStrings.dropLast(1), encodedShortStrings.last(), shortStrings.last().length)
+                Triple(encodedShortStrings.dropLast(1), encodedShortStrings.last(), shortStrings.last().length)
+
+            return StarknetByteArray(data.ifEmpty { listOf(Felt.ZERO) }, pendingWord, pendingWordLen)
         }
     }
 }

--- a/lib/src/main/kotlin/com/swmansion/starknet/extensions/SplitToShortStrings.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/extensions/SplitToShortStrings.kt
@@ -1,0 +1,9 @@
+package com.swmansion.starknet.extensions
+
+@JvmSynthetic
+internal fun String.splitToShortStrings(): List<String> {
+    val maxLen = 31
+    return (indices step maxLen).map {
+        substring(it, (it + maxLen).coerceAtMost(length))
+    }
+}

--- a/lib/src/test/kotlin/com/swmansion/starknet/data/types/ByteArrayTests.kt
+++ b/lib/src/test/kotlin/com/swmansion/starknet/data/types/ByteArrayTests.kt
@@ -19,7 +19,7 @@ internal class ByteArrayTests {
             return listOf(
                 ByteArrayTestCase(
                     input = "hello",
-                    data = listOf(Felt.ZERO),
+                    data = emptyList(),
                     pendingWord = Felt.fromHex("0x68656c6c6f"),
                     pendingWordLen = 5,
                 ),
@@ -46,13 +46,13 @@ internal class ByteArrayTests {
                 ),
                 ByteArrayTestCase(
                     input = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234",
-                    data = listOf(Felt.ZERO),
+                    data = listOf(),
                     pendingWord = Felt.fromHex("0x4142434445464748494a4b4c4d4e4f505152535455565758595a31323334"),
                     pendingWordLen = 30,
                 ),
                 ByteArrayTestCase(
                     input = "",
-                    data = listOf(Felt.ZERO),
+                    data = emptyList(),
                     pendingWord = Felt.ZERO,
                     pendingWordLen = 0,
                 ),

--- a/lib/src/test/kotlin/com/swmansion/starknet/data/types/ByteArrayTests.kt
+++ b/lib/src/test/kotlin/com/swmansion/starknet/data/types/ByteArrayTests.kt
@@ -1,0 +1,77 @@
+package com.swmansion.starknet.data.types
+
+import com.swmansion.starknet.extensions.toFelt
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+internal class ByteArrayTests {
+    data class ByteArrayTestCase(
+        val input: String,
+        val data: List<Felt>,
+        val pendingWord: Felt,
+        val pendingWordLen: Int,
+    )
+
+    companion object {
+        @JvmStatic
+        private fun getByteArrayFromString(): List<ByteArrayTestCase> {
+            return listOf(
+                ByteArrayTestCase(
+                    input = "hello",
+                    data = emptyList(),
+                    pendingWord = Felt.fromHex("0x68656c6c6f"),
+                    pendingWordLen = 5,
+                ),
+                ByteArrayTestCase(
+                    input = "Long string, more than 31 characters.",
+                    data = listOf(Felt.fromHex("0x4c6f6e6720737472696e672c206d6f7265207468616e203331206368617261")),
+                    pendingWord = Felt.fromHex("0x63746572732e"),
+                    pendingWordLen = 6,
+                ),
+                ByteArrayTestCase(
+                    input = "ABCDEFGHIJKLMNOPQRSTUVWXYZ12345AAADEFGHIJKLMNOPQRSTUVWXYZ12345A",
+                    data = listOf(
+                        Felt.fromHex("0x4142434445464748494a4b4c4d4e4f505152535455565758595a3132333435"),
+                        Felt.fromHex("0x4141414445464748494a4b4c4d4e4f505152535455565758595a3132333435"),
+                    ),
+                    pendingWord = Felt.fromHex("0x41"),
+                    pendingWordLen = 1,
+                ),
+                ByteArrayTestCase(
+                    input = "ABCDEFGHIJKLMNOPQRSTUVWXYZ12345",
+                    data = listOf(Felt.fromHex("0x4142434445464748494a4b4c4d4e4f505152535455565758595a3132333435")),
+                    pendingWord = Felt.ZERO,
+                    pendingWordLen = 0,
+                ),
+                ByteArrayTestCase(
+                    input = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234",
+                    data = listOf(),
+                    pendingWord = Felt.fromHex("0x4142434445464748494a4b4c4d4e4f505152535455565758595a31323334"),
+                    pendingWordLen = 30,
+                ),
+                ByteArrayTestCase(
+                    input = "",
+                    data = emptyList(),
+                    pendingWord = Felt.ZERO,
+                    pendingWordLen = 0,
+                ),
+            )
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("getByteArrayFromString")
+    fun `byte array from string`(testCase: ByteArrayTestCase) {
+        val byteArray = StarknetByteArray.fromString(testCase.input)
+
+        assertEquals(testCase.data, byteArray.data)
+        assertEquals(testCase.pendingWord, byteArray.pendingWord)
+        assertEquals(testCase.pendingWordLen, byteArray.pendingWordLen)
+
+        assertEquals(
+            listOf(testCase.data.size.toFelt) + testCase.data + listOf(testCase.pendingWord, testCase.pendingWordLen.toFelt),
+            byteArray.toCalldata(),
+        )
+    }
+}

--- a/lib/src/test/kotlin/com/swmansion/starknet/data/types/ByteArrayTests.kt
+++ b/lib/src/test/kotlin/com/swmansion/starknet/data/types/ByteArrayTests.kt
@@ -2,6 +2,9 @@ package com.swmansion.starknet.data.types
 
 import com.swmansion.starknet.extensions.toFelt
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 
@@ -73,5 +76,50 @@ internal class ByteArrayTests {
             listOf(testCase.data.size.toFelt) + testCase.data + listOf(testCase.pendingWord, testCase.pendingWordLen.toFelt),
             byteArray.toCalldata(),
         )
+    }
+
+    @Nested
+    inner class InvalidByteArrayTests {
+        @Test
+        fun `byte array from string with invalid pending word length`() {
+            val exception = assertThrows<IllegalArgumentException> {
+                StarknetByteArray(
+                    data = emptyList(),
+                    pendingWord = Felt.fromHex("0x68656c6c6f"),
+                    pendingWordLen = 31,
+                )
+            }
+
+            assertEquals("The length of 'pendingWord' must be between 0 and 30. [31] given.", exception.message)
+        }
+
+        @Test
+        fun `byte array from string with invalid pending word`() {
+            val exception = assertThrows<IllegalArgumentException> {
+                StarknetByteArray(
+                    data = emptyList(),
+                    pendingWord = Felt.fromHex("0x68656c6c6f"),
+                    pendingWordLen = 4,
+                )
+            }
+
+            assertEquals("The length of 'pendingWord' must be equal to 'pendingWordLen'. [0x68656c6c6f] of length [5] given.", exception.message)
+        }
+
+        @Test
+        fun `byte array from string with invalid data`() {
+            val exception = assertThrows<IllegalArgumentException> {
+                StarknetByteArray(
+                    data = listOf(
+                        Felt.fromHex("0x4142434445464748494a4b4c4d4e4f505152535455565758595a3132333435"),
+                        Felt.fromHex("0x68656c6c6f"),
+                    ),
+                    pendingWord = Felt.ZERO,
+                    pendingWordLen = 0,
+                )
+            }
+
+            assertEquals("All elements of 'data' must be 31 bytes long. [0x68656c6c6f] of length [5] given.", exception.message)
+        }
     }
 }

--- a/lib/src/test/kotlin/com/swmansion/starknet/data/types/ByteArrayTests.kt
+++ b/lib/src/test/kotlin/com/swmansion/starknet/data/types/ByteArrayTests.kt
@@ -19,7 +19,7 @@ internal class ByteArrayTests {
             return listOf(
                 ByteArrayTestCase(
                     input = "hello",
-                    data = emptyList(),
+                    data = listOf(Felt.ZERO),
                     pendingWord = Felt.fromHex("0x68656c6c6f"),
                     pendingWordLen = 5,
                 ),
@@ -46,13 +46,13 @@ internal class ByteArrayTests {
                 ),
                 ByteArrayTestCase(
                     input = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234",
-                    data = listOf(),
+                    data = listOf(Felt.ZERO),
                     pendingWord = Felt.fromHex("0x4142434445464748494a4b4c4d4e4f505152535455565758595a31323334"),
                     pendingWordLen = 30,
                 ),
                 ByteArrayTestCase(
                     input = "",
-                    data = emptyList(),
+                    data = listOf(Felt.ZERO),
                     pendingWord = Felt.ZERO,
                     pendingWordLen = 0,
                 ),


### PR DESCRIPTION
## Describe your changes

<!-- A brief description of the changes introduced in this PR -->
Related to and is needed for #428 

- Add `StarknetTypedData` that corresponds to `ByteArray` struct in Cairo

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->

## References

- [Serialization of byte arrays](https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/serialization_of_Cairo_types/#serialization_of_byte_arrays)
- Tests in [cairo repo](https://github.com/starkware-libs/cairo/blob/b22e43ffecf884877ed3a65d3077c0b8af586d6c/corelib/src/test/byte_array_test.cairo#L458)
