### PR TITLE
Use sealed classes for basic and preset types

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -123,6 +123,9 @@ dependencies {
     // Use the Kotlin JDK 8 standard library.
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.20")
 
+    // Use the Kotlin reflection library.
+    implementation(kotlin("reflect"))
+
     // Use the JUnit test library.
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.0")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.10.0")

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
@@ -402,21 +402,17 @@ data class TypedData private constructor(
             return typeName to hashArray(hashes)
         }
 
-        val basicType = BasicType.fromName(typeName, revision) ?: throw IllegalArgumentException("Type [$typeName] is not defined in types.")
+        val basicType = BasicType.fromName(typeName, revision)
+            ?: throw IllegalArgumentException("Type [$typeName] is not defined in types.")
 
-        return encodeBasicValue(basicType, value, context)
-    }
-
-    private fun encodeBasicValue(type: BasicType, value: JsonElement, context: Context?): Pair<String, Felt> {
-        require(type is BasicType.V0)
-        return when (type) {
+        return when (basicType) {
             BasicType.Felt -> "felt" to feltFromPrimitive(value.jsonPrimitive)
             BasicType.Bool -> "bool" to feltFromPrimitive(value.jsonPrimitive)
             BasicType.StringV0 -> "string" to feltFromPrimitive(value.jsonPrimitive)
             BasicType.StringV1 -> "string" to prepareLongString(value.jsonPrimitive.content)
             BasicType.Selector -> "felt" to prepareSelector(value.jsonPrimitive.content)
             BasicType.I128 -> "i128" to feltFromPrimitive(value.jsonPrimitive, allowSigned = true)
-            BasicType.U128, BasicType.ContractAddress, BasicType.ClassHash, BasicType.Timestamp, BasicType.ShortString -> type.typeName to feltFromPrimitive(value.jsonPrimitive)
+            BasicType.U128, BasicType.ContractAddress, BasicType.ClassHash, BasicType.Timestamp, BasicType.ShortString -> basicType.typeName to feltFromPrimitive(value.jsonPrimitive)
             BasicType.MerkleTree -> {
                 requireNotNull(context) { "Context is not provided for 'merkletree' type." }
                 "felt" to prepareMerkletreeRoot(value.jsonArray, context)

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
@@ -109,7 +109,7 @@ data class TypedData private constructor(
     private val revision = domain.revision ?: Revision.V0
 
     @Transient
-    private val types: Map<String, List<Type>> = customTypes + PresetTypes.values(revision).associate { it.typeName to it.params }
+    private val types: Map<String, List<Type>> = customTypes + PresetType.values(revision).associate { it.typeName to it.params }
 
     private val hashMethod by lazy {
         when (revision) {
@@ -128,7 +128,7 @@ data class TypedData private constructor(
         require(domain.separatorName in customTypes) { "Types must contain '${domain.separatorName}'." }
 
         BasicType.values(revision).forEach { require(it.typeName !in customTypes) { "Types must not contain basic types. [${it.typeName}] was found." } }
-        PresetTypes.values(revision).forEach { require(it.typeName !in customTypes) { "Types must not contain preset types. [$it] was found." } }
+        PresetType.values(revision).forEach { require(it.typeName !in customTypes) { "Types must not contain preset types. [$it] was found." } }
 
         val referencedTypes = customTypes.values.flatten().flatMap {
             when (it) {
@@ -517,24 +517,24 @@ data class TypedData private constructor(
             }
         }
 
-        private interface PresetTypes {
+        private interface PresetType {
             val typeName: String
             val params: List<Type>
 
             companion object {
-                internal fun values(revision: Revision): List<PresetTypes> {
+                internal fun values(revision: Revision): List<PresetType> {
                     return when (revision) {
                         Revision.V0 -> emptyList()
-                        Revision.V1 -> PresetTypesV1.entries
+                        Revision.V1 -> PresetTypeV1.entries
                     }
                 }
             }
         }
 
-        enum class PresetTypesV1(
+        enum class PresetTypeV1(
             override val typeName: String,
             override val params: List<Type>,
-        ) : PresetTypes {
+        ) : PresetType {
             U256(
                 "u256",
                 listOf(

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
@@ -403,11 +403,11 @@ data class TypedData private constructor(
 
         return basicType.encodeToType to when (basicType) {
             BasicType.Felt, BasicType.StringV0, BasicType.ShortString, BasicType.ContractAddress, BasicType.ClassHash -> feltFromPrimitive(value.jsonPrimitive)
-            BasicType.Bool -> boolFromPrimitive(value.jsonPrimitive)
+            BasicType.Bool -> feltFromPrimitive(value.jsonPrimitive)
             BasicType.Selector -> prepareSelector(value.jsonPrimitive.content)
             BasicType.StringV1 -> prepareLongString(value.jsonPrimitive.content)
-            BasicType.I128 -> i128fromPrimitive(value.jsonPrimitive)
-            BasicType.U128, BasicType.Timestamp -> u128fromPrimitive(value.jsonPrimitive)
+            BasicType.I128 -> feltFromPrimitive(value.jsonPrimitive, allowSigned = true)
+            BasicType.U128, BasicType.Timestamp -> feltFromPrimitive(value.jsonPrimitive)
             BasicType.MerkleTree -> {
                 requireNotNull(context) { "Context is not provided for 'merkletree' type." }
                 prepareMerkletreeRoot(value.jsonArray, context)

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
@@ -294,12 +294,19 @@ data class TypedData private constructor(
         return "${escape(dependency)}($encodedFields)"
     }
 
-    private fun feltFromPrimitive(primitive: JsonPrimitive, allowSigned: Boolean = false): Felt {
+    private fun feltFromPrimitive(
+        primitive: JsonPrimitive,
+        allowSigned: Boolean = false,
+        allowBoolean: Boolean = false,
+        allowShortString: Boolean = true,
+    ): Felt {
         val decimal = primitive.content.toBigIntegerOrNull()
         decimal?.let {
             return if (allowSigned) Felt.fromSigned(it) else Felt(it)
         }
-        primitive.booleanOrNull?.let {
+        val boolean = primitive.booleanOrNull
+        boolean?.let {
+            require(allowBoolean) { "Unexpected boolean value: [$primitive]" }
             return if (it) Felt.ONE else Felt.ZERO
         }
 
@@ -311,11 +318,36 @@ data class TypedData private constructor(
             return try {
                 Felt.fromHex(primitive.content)
             } catch (e: Exception) {
+                require(allowShortString) { "Unexpected string value: [$primitive]." }
                 Felt.fromShortString(primitive.content)
             }
         }
 
-        throw IllegalArgumentException("Unsupported primitive type: $primitive")
+        throw IllegalArgumentException("Unsupported primitive type: [$primitive]")
+    }
+
+    private fun boolFromPrimitive(primitive: JsonPrimitive): Felt {
+        val felt = feltFromPrimitive(primitive, allowBoolean = true, allowShortString = false)
+
+        require(felt.value < BigInteger.TWO) { "Expected boolean value, got [$primitive]." }
+
+        return felt
+    }
+
+    private fun u128fromPrimitive(primitive: JsonPrimitive): Felt {
+        val felt = feltFromPrimitive(primitive, allowShortString = false)
+
+        require(felt.value < BigInteger.TWO.pow(128)) { "Value [$felt] is out of range for 'u128'." }
+
+        return felt
+    }
+
+    private fun i128fromPrimitive(primitive: JsonPrimitive): Felt {
+        val felt = feltFromPrimitive(primitive, allowSigned = true, allowShortString = false)
+
+        require(felt.value < BigInteger.TWO.pow(127) || felt.value > Felt.PRIME - BigInteger.TWO.pow(127)) { "Value [$primitive] is out of range for 'i128'." }
+
+        return felt
     }
 
     private fun prepareLongString(string: String): Felt {
@@ -401,21 +433,22 @@ data class TypedData private constructor(
         val basicType = BasicType.fromName(typeName, revision)
             ?: throw IllegalArgumentException("Type [$typeName] is not defined in types.")
 
-        return when (basicType) {
-            BasicType.Felt -> "felt" to feltFromPrimitive(value.jsonPrimitive)
-            BasicType.Bool -> "bool" to feltFromPrimitive(value.jsonPrimitive)
-            BasicType.Selector -> "felt" to prepareSelector(value.jsonPrimitive.content)
-            BasicType.StringV0 -> "string" to feltFromPrimitive(value.jsonPrimitive)
-            BasicType.StringV1 -> "string" to prepareLongString(value.jsonPrimitive.content)
-            BasicType.I128 -> "i128" to feltFromPrimitive(value.jsonPrimitive, allowSigned = true)
-            BasicType.U128, BasicType.ContractAddress, BasicType.ClassHash, BasicType.Timestamp, BasicType.ShortString -> basicType.name to feltFromPrimitive(value.jsonPrimitive)
-            BasicType.MerkleTree -> {
-                requireNotNull(context) { "Context is not provided for 'merkletree' type." }
-                "felt" to prepareMerkletreeRoot(value.jsonArray, context)
-            }
-            BasicType.Enum -> {
-                requireNotNull(context) { "Context is not provided for 'enum' type." }
-                "felt" to prepareEnum(value.jsonObject, context)
+        return basicType.let { t ->
+            when (t) {
+                BasicType.Felt, BasicType.StringV0, BasicType.ShortString, BasicType.ContractAddress, BasicType.ClassHash -> t.name to feltFromPrimitive(value.jsonPrimitive)
+                BasicType.Bool -> t.name to feltFromPrimitive(value.jsonPrimitive)
+                BasicType.Selector -> BasicType.Felt.name to prepareSelector(value.jsonPrimitive.content)
+                BasicType.StringV1 -> t.name to prepareLongString(value.jsonPrimitive.content)
+                BasicType.I128 -> t.name to feltFromPrimitive(value.jsonPrimitive)
+                BasicType.U128, BasicType.Timestamp -> t.name to feltFromPrimitive(value.jsonPrimitive)
+                BasicType.MerkleTree -> {
+                    requireNotNull(context) { "Context is not provided for 'merkletree' type." }
+                    BasicType.Felt.name to prepareMerkletreeRoot(value.jsonArray, context)
+                }
+                BasicType.Enum -> {
+                    requireNotNull(context) { "Context is not provided for 'enum' type." }
+                    BasicType.Felt.name to prepareEnum(value.jsonObject, context)
+                }
             }
         }
     }

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
@@ -474,84 +474,84 @@ data class TypedData private constructor(
         )
     }
 
+    private sealed class BasicType {
+        abstract val typeName: String
+
+        override fun toString() = typeName
+
+        sealed interface V0
+        sealed interface V1
+
+        data object Felt : BasicType(), V0, V1 { override val typeName = "felt" }
+        data object Bool : BasicType(), V0, V1 { override val typeName = "bool" }
+        data object Selector : BasicType(), V0, V1 { override val typeName = "selector" }
+        data object MerkleTree : BasicType(), V0, V1 { override val typeName = "merkletree" }
+        data object StringV0 : BasicType(), V0 { override val typeName = "string" }
+        data object StringV1 : BasicType(), V1 { override val typeName = "string" }
+        data object Enum : BasicType(), V1 { override val typeName = "enum" }
+        data object I128 : BasicType(), V1 { override val typeName = "i128" }
+        data object U128 : BasicType(), V1 { override val typeName = "u128" }
+        data object ContractAddress : BasicType(), V1 { override val typeName = "ContractAddress" }
+        data object ClassHash : BasicType(), V1 { override val typeName = "ClassHash" }
+        data object Timestamp : BasicType(), V1 { override val typeName = "timestamp" }
+        data object ShortString : BasicType(), V1 { override val typeName = "shortstring" }
+
+        companion object {
+            fun values(revision: Revision): List<BasicType> {
+                val instances = BasicType::class.sealedSubclasses.mapNotNull { it.objectInstance }
+
+                return when (revision) {
+                    Revision.V0 -> instances.filterIsInstance<V0>()
+                    Revision.V1 -> instances.filterIsInstance<V1>()
+                }.map { it as BasicType }
+            }
+
+            fun fromName(typeName: String, revision: Revision): BasicType? {
+                return values(revision).find { it.typeName == typeName }
+            }
+        }
+    }
+
+    private sealed class PresetType {
+        abstract val typeName: String
+        abstract val params: List<Type>
+
+        override fun toString() = typeName
+
+        sealed interface V1
+
+        data object U256 : PresetType(), V1 {
+            override val typeName = "u256"
+            override val params = listOf(
+                StandardType("low", "u128"),
+                StandardType("high", "u128"),
+            )
+        }
+        data object TokenAmount : PresetType(), V1 {
+            override val typeName = "TokenAmount"
+            override val params = listOf(
+                StandardType("token_address", "ContractAddress"),
+                StandardType("amount", "u256"),
+            )
+        }
+        data object NftId : PresetType(), V1 {
+            override val typeName = "NftId"
+            override val params = listOf(
+                StandardType("collection_address", "ContractAddress"),
+                StandardType("token_id", "u256"),
+            )
+        }
+        companion object {
+            fun values(revision: Revision): List<PresetType> {
+                return when (revision) {
+                    Revision.V0 -> emptyList()
+                    Revision.V1 -> PresetType::class.sealedSubclasses.mapNotNull { it.objectInstance }.filterIsInstance<V1>()
+                }.map { it as PresetType }
+            }
+        }
+    }
+
     companion object {
-        private sealed class BasicType {
-            abstract val typeName: String
-
-            override fun toString() = typeName
-
-            sealed interface V0
-            sealed interface V1
-
-            data object Felt : BasicType(), V0, V1 { override val typeName = "felt" }
-            data object Bool : BasicType(), V0, V1 { override val typeName = "bool" }
-            data object Selector : BasicType(), V0, V1 { override val typeName = "selector" }
-            data object MerkleTree : BasicType(), V0, V1 { override val typeName = "merkletree" }
-            data object StringV0 : BasicType(), V0 { override val typeName = "string" }
-            data object StringV1 : BasicType(), V1 { override val typeName = "string" }
-            data object Enum : BasicType(), V1 { override val typeName = "enum" }
-            data object I128 : BasicType(), V1 { override val typeName = "i128" }
-            data object U128 : BasicType(), V1 { override val typeName = "u128" }
-            data object ContractAddress : BasicType(), V1 { override val typeName = "ContractAddress" }
-            data object ClassHash : BasicType(), V1 { override val typeName = "ClassHash" }
-            data object Timestamp : BasicType(), V1 { override val typeName = "timestamp" }
-            data object ShortString : BasicType(), V1 { override val typeName = "shortstring" }
-
-            companion object {
-                fun values(revision: Revision): List<BasicType> {
-                    val instances = BasicType::class.sealedSubclasses.mapNotNull { it.objectInstance }
-
-                    return when (revision) {
-                        Revision.V0 -> instances.filterIsInstance<V0>()
-                        Revision.V1 -> instances.filterIsInstance<V1>()
-                    }.map { it as BasicType }
-                }
-
-                fun fromName(typeName: String, revision: Revision): BasicType? {
-                    return values(revision).find { it.typeName == typeName }
-                }
-            }
-        }
-
-        private sealed class PresetType {
-            abstract val typeName: String
-            abstract val params: List<Type>
-
-            override fun toString() = typeName
-
-            sealed interface V1
-
-            data object U256 : PresetType(), V1 {
-                override val typeName = "u256"
-                override val params = listOf(
-                    StandardType("low", "u128"),
-                    StandardType("high", "u128"),
-                )
-            }
-            data object TokenAmount : PresetType(), V1 {
-                override val typeName = "TokenAmount"
-                override val params = listOf(
-                    StandardType("token_address", "ContractAddress"),
-                    StandardType("amount", "u256"),
-                )
-            }
-            data object NftId : PresetType(), V1 {
-                override val typeName = "NftId"
-                override val params = listOf(
-                    StandardType("collection_address", "ContractAddress"),
-                    StandardType("token_id", "u256"),
-                )
-            }
-            companion object {
-                fun values(revision: Revision): List<PresetType> {
-                    return when (revision) {
-                        Revision.V0 -> emptyList()
-                        Revision.V1 -> PresetType::class.sealedSubclasses.mapNotNull { it.objectInstance }.filterIsInstance<V1>()
-                    }.map { it as PresetType }
-                }
-            }
-        }
-
         /**
          * Create TypedData from JSON string.
          *

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
@@ -129,7 +129,7 @@ data class TypedData private constructor(
         val referencedTypes = types.values.flatten().flatMap {
             when (it) {
                 is EnumType -> {
-                    require(revision == Revision.V1) { "'enum' basic type is not supported in revision ${revision.value}." }
+                    require(revision == Revision.V1) { "'${BasicType.Enum.name}' basic type is not supported in revision ${revision.value}." }
                     listOf(it.contains)
                 }
                 is MerkleTreeType -> listOf(it.contains)
@@ -197,7 +197,7 @@ data class TypedData private constructor(
     @Serializable
     data class MerkleTreeType(
         override val name: String,
-        override val type: String = "merkletree",
+        override val type: String = BasicType.MerkleTree.name,
         val contains: String,
     ) : Type() {
         init {
@@ -210,7 +210,7 @@ data class TypedData private constructor(
     @Serializable
     data class EnumType(
         override val name: String,
-        override val type: String = "enum",
+        override val type: String = BasicType.Enum.name,
         val contains: String,
     ) : Type()
 
@@ -230,7 +230,7 @@ data class TypedData private constructor(
             params.forEach { param ->
                 val extractedTypes = when {
                     param is EnumType -> {
-                        require(revision == Revision.V1) { "'enum' basic type is not supported in revision ${revision.value}." }
+                        require(revision == Revision.V1) { "'${BasicType.Enum.name}' basic type is not supported in revision ${revision.value}." }
                         listOf(param.contains)
                     }
                     param.type.isEnum() -> {
@@ -371,7 +371,7 @@ data class TypedData private constructor(
 
         val variants = getEnumVariants(context)
         val variantType = variants.singleOrNull { it.name == variantName }
-            ?: throw IllegalArgumentException("Variant [$variantName] is not defined in 'enum' type [${context.key}] or multiple definitions are present.")
+            ?: throw IllegalArgumentException("Variant [$variantName] is not defined in '${BasicType.Enum.name}' type [${context.key}] or multiple definitions are present.")
         val variantIndex = variants.indexOf(variantType)
 
         val encodedSubtypes = extractEnumTypes(variantType.type).mapIndexed { index, subtype ->
@@ -409,11 +409,11 @@ data class TypedData private constructor(
             BasicType.I128 -> feltFromPrimitive(value.jsonPrimitive, allowSigned = true)
             BasicType.U128, BasicType.Timestamp -> feltFromPrimitive(value.jsonPrimitive)
             BasicType.MerkleTree -> {
-                requireNotNull(context) { "Context is not provided for 'merkletree' type." }
+                requireNotNull(context) { "Context is not provided for '${basicType.name}' type." }
                 prepareMerkletreeRoot(value.jsonArray, context)
             }
             BasicType.Enum -> {
-                requireNotNull(context) { "Context is not provided for 'enum' type." }
+                requireNotNull(context) { "Context is not provided for '${basicType.name}' type." }
                 prepareEnum(value.jsonObject, context)
             }
         }

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
@@ -401,22 +401,20 @@ data class TypedData private constructor(
         val basicType = BasicType.fromName(typeName, revision)
             ?: throw IllegalArgumentException("Type [$typeName] is not defined in types.")
 
-        return basicType.let { t ->
-            when (t) {
-                BasicType.Felt, BasicType.StringV0, BasicType.ShortString, BasicType.ContractAddress, BasicType.ClassHash -> t.name to feltFromPrimitive(value.jsonPrimitive)
-                BasicType.Bool -> t.name to feltFromPrimitive(value.jsonPrimitive)
-                BasicType.Selector -> BasicType.Felt.name to prepareSelector(value.jsonPrimitive.content)
-                BasicType.StringV1 -> t.name to prepareLongString(value.jsonPrimitive.content)
-                BasicType.I128 -> t.name to feltFromPrimitive(value.jsonPrimitive, allowSigned = true)
-                BasicType.U128, BasicType.Timestamp -> t.name to feltFromPrimitive(value.jsonPrimitive)
-                BasicType.MerkleTree -> {
-                    requireNotNull(context) { "Context is not provided for 'merkletree' type." }
-                    BasicType.Felt.name to prepareMerkletreeRoot(value.jsonArray, context)
-                }
-                BasicType.Enum -> {
-                    requireNotNull(context) { "Context is not provided for 'enum' type." }
-                    BasicType.Felt.name to prepareEnum(value.jsonObject, context)
-                }
+        return basicType.encodeToType to when (basicType) {
+            BasicType.Felt, BasicType.StringV0, BasicType.ShortString, BasicType.ContractAddress, BasicType.ClassHash -> feltFromPrimitive(value.jsonPrimitive)
+            BasicType.Bool -> boolFromPrimitive(value.jsonPrimitive)
+            BasicType.Selector -> prepareSelector(value.jsonPrimitive.content)
+            BasicType.StringV1 -> prepareLongString(value.jsonPrimitive.content)
+            BasicType.I128 -> i128fromPrimitive(value.jsonPrimitive)
+            BasicType.U128, BasicType.Timestamp -> u128fromPrimitive(value.jsonPrimitive)
+            BasicType.MerkleTree -> {
+                requireNotNull(context) { "Context is not provided for 'merkletree' type." }
+                prepareMerkletreeRoot(value.jsonArray, context)
+            }
+            BasicType.Enum -> {
+                requireNotNull(context) { "Context is not provided for 'enum' type." }
+                prepareEnum(value.jsonObject, context)
             }
         }
     }
@@ -477,17 +475,18 @@ data class TypedData private constructor(
 
     private sealed class BasicType {
         abstract val name: String
+        open val encodeToType get() = name
 
         sealed interface V0
         sealed interface V1
 
         data object Felt : BasicType(), V0, V1 { override val name = "felt" }
         data object Bool : BasicType(), V0, V1 { override val name = "bool" }
-        data object Selector : BasicType(), V0, V1 { override val name = "selector" }
-        data object MerkleTree : BasicType(), V0, V1 { override val name = "merkletree" }
+        data object Selector : BasicType(), V0, V1 { override val name = "selector"; override val encodeToType = Felt.name }
+        data object MerkleTree : BasicType(), V0, V1 { override val name = "merkletree"; override val encodeToType = Felt.name }
         data object StringV0 : BasicType(), V0 { override val name = "string" }
         data object StringV1 : BasicType(), V1 { override val name = "string" }
-        data object Enum : BasicType(), V1 { override val name = "enum" }
+        data object Enum : BasicType(), V1 { override val name = "enum"; override val encodeToType = Felt.name }
         data object I128 : BasicType(), V1 { override val name = "i128" }
         data object U128 : BasicType(), V1 { override val name = "u128" }
         data object ContractAddress : BasicType(), V1 { override val name = "ContractAddress" }

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
@@ -404,9 +404,9 @@ data class TypedData private constructor(
         return when (basicType) {
             BasicType.Felt -> "felt" to feltFromPrimitive(value.jsonPrimitive)
             BasicType.Bool -> "bool" to feltFromPrimitive(value.jsonPrimitive)
+            BasicType.Selector -> "felt" to prepareSelector(value.jsonPrimitive.content)
             BasicType.StringV0 -> "string" to feltFromPrimitive(value.jsonPrimitive)
             BasicType.StringV1 -> "string" to prepareLongString(value.jsonPrimitive.content)
-            BasicType.Selector -> "felt" to prepareSelector(value.jsonPrimitive.content)
             BasicType.I128 -> "i128" to feltFromPrimitive(value.jsonPrimitive, allowSigned = true)
             BasicType.U128, BasicType.ContractAddress, BasicType.ClassHash, BasicType.Timestamp, BasicType.ShortString -> basicType.name to feltFromPrimitive(value.jsonPrimitive)
             BasicType.MerkleTree -> {

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
@@ -457,10 +457,10 @@ data class TypedData private constructor(
         }
     }
 
-    fun getStructHash(name: String, data: String): Felt {
-        val encodedData = encodeData(name, Json.parseToJsonElement(data).jsonObject)
+    fun getStructHash(typeName: String, data: String): Felt {
+        val encodedData = encodeData(typeName, Json.parseToJsonElement(data).jsonObject)
 
-        return hashArray(listOf(getTypeHash(name)) + encodedData)
+        return hashArray(listOf(getTypeHash(typeName)) + encodedData)
     }
 
     fun getMessageHash(accountAddress: Felt): Felt {

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
@@ -477,8 +477,6 @@ data class TypedData private constructor(
     private sealed class BasicType {
         abstract val typeName: String
 
-        override fun toString() = typeName
-
         sealed interface V0
         sealed interface V1
 
@@ -515,8 +513,6 @@ data class TypedData private constructor(
     private sealed class PresetType {
         abstract val typeName: String
         abstract val params: List<Type>
-
-        override fun toString() = typeName
 
         sealed interface V1
 

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
@@ -402,20 +402,19 @@ data class TypedData private constructor(
             ?: throw IllegalArgumentException("Type [$typeName] is not defined in types.")
 
         return basicType.encodeToType to when (basicType) {
-            BasicType.Felt, BasicType.StringV0, BasicType.ShortString, BasicType.ContractAddress, BasicType.ClassHash -> feltFromPrimitive(value.jsonPrimitive)
-            BasicType.Bool -> feltFromPrimitive(value.jsonPrimitive)
-            BasicType.Selector -> prepareSelector(value.jsonPrimitive.content)
-            BasicType.StringV1 -> prepareLongString(value.jsonPrimitive.content)
-            BasicType.I128 -> feltFromPrimitive(value.jsonPrimitive, allowSigned = true)
-            BasicType.U128, BasicType.Timestamp -> feltFromPrimitive(value.jsonPrimitive)
-            BasicType.MerkleTree -> {
-                requireNotNull(context) { "Context is not provided for '${basicType.name}' type." }
-                prepareMerkletreeRoot(value.jsonArray, context)
-            }
             BasicType.Enum -> {
                 requireNotNull(context) { "Context is not provided for '${basicType.name}' type." }
                 prepareEnum(value.jsonObject, context)
             }
+            BasicType.MerkleTree -> {
+                requireNotNull(context) { "Context is not provided for '${basicType.name}' type." }
+                prepareMerkletreeRoot(value.jsonArray, context)
+            }
+            BasicType.StringV0 -> feltFromPrimitive(value.jsonPrimitive)
+            BasicType.StringV1 -> prepareLongString(value.jsonPrimitive.content)
+            BasicType.Selector -> prepareSelector(value.jsonPrimitive.content)
+            BasicType.I128 -> feltFromPrimitive(value.jsonPrimitive, allowSigned = true)
+            BasicType.Felt, BasicType.Bool, BasicType.ShortString, BasicType.ContractAddress, BasicType.ClassHash, BasicType.U128, BasicType.Timestamp -> feltFromPrimitive(value.jsonPrimitive)
         }
     }
 

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
@@ -516,6 +516,7 @@ data class TypedData private constructor(
 
         sealed interface V1
 
+        @Suppress("unused")
         data object U256 : PresetType(), V1 {
             override val name = "u256"
             override val params = listOf(
@@ -523,6 +524,8 @@ data class TypedData private constructor(
                 StandardType("high", "u128"),
             )
         }
+
+        @Suppress("unused")
         data object TokenAmount : PresetType(), V1 {
             override val name = "TokenAmount"
             override val params = listOf(
@@ -530,6 +533,8 @@ data class TypedData private constructor(
                 StandardType("amount", "u256"),
             )
         }
+
+        @Suppress("unused")
         data object NftId : PresetType(), V1 {
             override val name = "NftId"
             override val params = listOf(

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
@@ -487,19 +487,19 @@ data class TypedData private constructor(
             sealed interface V0
             sealed interface V1
 
-            data object Felt : BasicType(), V0, V1 { override val typeName: String = "felt" }
-            data object Bool : BasicType(), V0, V1 { override val typeName: String = "bool" }
-            data object Selector : BasicType(), V0, V1 { override val typeName: String = "selector" }
-            data object MerkleTree : BasicType(), V0, V1 { override val typeName: String = "merkletree" }
-            data object StringV0 : BasicType(), V0 { override val typeName: String = "string" }
-            data object StringV1 : BasicType(), V1 { override val typeName: String = "string" }
-            data object Enum : BasicType(), V1 { override val typeName: String = "enum" }
-            data object I128 : BasicType(), V1 { override val typeName: String = "i128" }
-            data object U128 : BasicType(), V1 { override val typeName: String = "u128" }
-            data object ContractAddress : BasicType(), V1 { override val typeName: String = "ContractAddress" }
-            data object ClassHash : BasicType(), V1 { override val typeName: String = "ClassHash" }
-            data object Timestamp : BasicType(), V1 { override val typeName: String = "timestamp" }
-            data object ShortString : BasicType(), V1 { override val typeName: String = "shortstring" }
+            data object Felt : BasicType(), V0, V1 { override val typeName = "felt" }
+            data object Bool : BasicType(), V0, V1 { override val typeName = "bool" }
+            data object Selector : BasicType(), V0, V1 { override val typeName = "selector" }
+            data object MerkleTree : BasicType(), V0, V1 { override val typeName = "merkletree" }
+            data object StringV0 : BasicType(), V0 { override val typeName = "string" }
+            data object StringV1 : BasicType(), V1 { override val typeName = "string" }
+            data object Enum : BasicType(), V1 { override val typeName = "enum" }
+            data object I128 : BasicType(), V1 { override val typeName = "i128" }
+            data object U128 : BasicType(), V1 { override val typeName = "u128" }
+            data object ContractAddress : BasicType(), V1 { override val typeName = "ContractAddress" }
+            data object ClassHash : BasicType(), V1 { override val typeName = "ClassHash" }
+            data object Timestamp : BasicType(), V1 { override val typeName = "timestamp" }
+            data object ShortString : BasicType(), V1 { override val typeName = "shortstring" }
 
             companion object {
                 fun values(revision: Revision): List<BasicType> {
@@ -526,22 +526,22 @@ data class TypedData private constructor(
             sealed interface V1
 
             data object U256 : PresetType(), V1 {
-                override val typeName: String = "u256"
-                override val params: List<Type> = listOf(
+                override val typeName = "u256"
+                override val params = listOf(
                     StandardType("low", "u128"),
                     StandardType("high", "u128"),
                 )
             }
             data object TokenAmount : PresetType(), V1 {
-                override val typeName: String = "TokenAmount"
-                override val params: List<Type> = listOf(
+                override val typeName = "TokenAmount"
+                override val params = listOf(
                     StandardType("token_address", "ContractAddress"),
                     StandardType("amount", "u256"),
                 )
             }
             data object NftId : PresetType(), V1 {
-                override val typeName: String = "NftId"
-                override val params: List<Type> = listOf(
+                override val typeName = "NftId"
+                override val params = listOf(
                     StandardType("collection_address", "ContractAddress"),
                     StandardType("token_id", "u256"),
                 )

--- a/lib/src/test/kotlin/starknet/data/TypedDataTest.kt
+++ b/lib/src/test/kotlin/starknet/data/TypedDataTest.kt
@@ -416,11 +416,11 @@ internal class TypedDataTest {
         val invalidParentContext = Context(parent = "UndefinedParent", key = "root")
         val invalidKeyContext = Context(parent = "Session", key = "undefinedKey")
 
-        val parentException = assertThrows<IllegalArgumentException>{
+        val parentException = assertThrows<IllegalArgumentException> {
             CasesRev0.TD_STRUCT_MERKLETREE.encodeValue("merkletree", Json.encodeToJsonElement(leaves), invalidParentContext)
         }
         assertEquals("Parent [${invalidParentContext.parent}] is not defined in types.", parentException.message)
-        val keyException = assertThrows<IllegalArgumentException>{
+        val keyException = assertThrows<IllegalArgumentException> {
             CasesRev0.TD_STRUCT_MERKLETREE.encodeValue("merkletree", Json.encodeToJsonElement(leaves), invalidKeyContext)
         }
         assertEquals("Key [${invalidKeyContext.key}] is not defined in type [${invalidKeyContext.parent}] or multiple definitions are present.", keyException.message)


### PR DESCRIPTION
## Describe your changes

<!-- A brief description of the changes introduced in this PR -->

This PR is part of the stack:

-- Update TypedData in line with SNIP-12 (#428) 
-- Use sealed classes for basic and preset types (#440)
-- Add separate methods for primitives (#442)
-- Nest TypedData-related test cases (#434)

- Add `BasicType` sealed class
  - Represent each basic type as data object inheriting `BasicType`
  - Add `BasicType.V0` and `BasicType.V1` sealed interfaces to allow specifying supported revisions by the given basic types
  - Use single data class for every type that is not revision-specific
- Add `PresetType` sealed class
  - Same approach as `BasicType`
- Use `BasicType.values(revision)` and `PresetType.values(revision)` instead of `getBasicTypes` and `getPresetTypes` respectively  
- Move `BasicType` and `PresetType` out of companion object
- Add `kotlin-reflect` dependency

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
