### PR TITLE
Fix build for android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,8 +57,8 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
-    implementation 'org.bouncycastle:bcprov-jdk18on:1.76'
-    implementation("com.squareup.okhttp3:okhttp:4.11.0")
+    implementation 'org.bouncycastle:bcprov-jdk18on:1.77'
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1")
     implementation 'org.jetbrains.kotlin:kotlin-reflect:1.9.23'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -60,4 +60,5 @@ dependencies {
     implementation 'org.bouncycastle:bcprov-jdk18on:1.76'
     implementation("com.squareup.okhttp3:okhttp:4.11.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1")
+    implementation 'org.jetbrains.kotlin:kotlin-reflect:1.9.23'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     implementation 'org.bouncycastle:bcprov-jdk18on:1.77'
-    implementation("com.squareup.okhttp3:okhttp:4.12.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1")
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1'
     implementation 'org.jetbrains.kotlin:kotlin-reflect:1.9.23'
 }

--- a/lib/src/main/kotlin/com/swmansion/starknet/crypto/NativeLoader.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/crypto/NativeLoader.kt
@@ -57,7 +57,7 @@ internal object NativeLoader {
     class UnsupportedPlatform(system: String, architecture: String) :
         RuntimeException("Unsupported platfrom $system:$architecture")
 
-    class UnknownOS : RuntimeException("Unknown OS")
+    class UnknownOS : RuntimeException("Failed to fetch OS name")
 
     private fun getLibPath(system: SystemType, architecture: String, name: String): String {
         return when (system) {

--- a/lib/src/main/kotlin/com/swmansion/starknet/crypto/NativeLoader.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/crypto/NativeLoader.kt
@@ -7,7 +7,7 @@ import java.util.*
 
 internal object NativeLoader {
     private val operatingSystem: SystemType by lazy {
-        val system = System.getProperty("os.name", "generic").lowercase(Locale.ENGLISH)
+        val system = System.getProperty("os.name", "generic")?.lowercase(Locale.ENGLISH) ?: throw UnknownOS()
         when {
             system.contains("mac") || system.contains("darwin") -> SystemType.MacOS
             system.contains("win") -> SystemType.Windows
@@ -56,6 +56,8 @@ internal object NativeLoader {
 
     class UnsupportedPlatform(system: String, architecture: String) :
         RuntimeException("Unsupported platfrom $system:$architecture")
+
+    class UnknownOS : RuntimeException("Unknown OS")
 
     private fun getLibPath(system: SystemType, architecture: String, name: String): String {
         return when (system) {

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
@@ -331,7 +331,7 @@ data class TypedData private constructor(
     private fun boolFromPrimitive(primitive: JsonPrimitive): Felt {
         val felt = feltFromPrimitive(primitive, allowBoolean = true, allowShortString = false)
 
-        require(felt.value < BigInteger.TWO) { "Expected boolean value, got [$primitive]." }
+        require(felt.value < BigInteger.valueOf(2)) { "Expected boolean value, got [$primitive]." }
 
         return felt
     }
@@ -339,7 +339,7 @@ data class TypedData private constructor(
     private fun u128fromPrimitive(primitive: JsonPrimitive): Felt {
         val felt = feltFromPrimitive(primitive, allowShortString = false)
 
-        require(felt.value < BigInteger.TWO.pow(128)) { "Value [$primitive] is out of range for '${BasicType.U128.name}'." }
+        require(felt.value < BigInteger.valueOf(2).pow(128)) { "Value [$primitive] is out of range for '${BasicType.U128.name}'." }
 
         return felt
     }
@@ -347,7 +347,7 @@ data class TypedData private constructor(
     private fun i128fromPrimitive(primitive: JsonPrimitive): Felt {
         val felt = feltFromPrimitive(primitive, allowSigned = true, allowShortString = false)
 
-        require(felt.value < BigInteger.TWO.pow(127) || felt.value >= Felt.PRIME - BigInteger.TWO.pow(127)) { "Value [$primitive] is out of range for '${BasicType.I128.name}'." }
+        require(felt.value < BigInteger.valueOf(2).pow(127) || felt.value >= Felt.PRIME - BigInteger.valueOf(2).pow(127)) { "Value [$primitive] is out of range for '${BasicType.I128.name}'." }
 
         return felt
     }


### PR DESCRIPTION
## Describe your changes

<!-- A brief description of the changes introduced in this PR -->
 
Fix errors and warnings observed when running `:android:compileDebugKotlin` that caused 0.11.1 release to fail. 
 
- Don't use `BigInteger.TWO`: not supported in Java 1.8
- `android` deps
  - Add `kotlin-reflect`
  - Bump and format deps
- Update `NativeLoader` to handle `System.getProperty()` returning null

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
