### PR TITLE
Prepend array length in `FeltArray` serialization

### DIFF
--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/FeltArray.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/FeltArray.kt
@@ -1,6 +1,7 @@
 package com.swmansion.starknet.data.types
 
 import com.swmansion.starknet.data.types.conversions.ConvertibleToCalldata
+import com.swmansion.starknet.extensions.toFelt
 
 data class FeltArray(private val list: MutableList<Felt>) : ConvertibleToCalldata, MutableList<Felt> by list {
     constructor(vararg elements: Felt) : this(elements.toMutableList())

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/FeltArray.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/FeltArray.kt
@@ -7,5 +7,8 @@ data class FeltArray(private val list: MutableList<Felt>) : ConvertibleToCalldat
     constructor(collection: Collection<Felt>) : this(collection.toMutableList())
     constructor() : this(emptyList())
 
-    override fun toCalldata(): List<Felt> = list.toList()
+    override fun toCalldata(): List<Felt> {
+        val elementsNumber = Felt(list.size.toBigInteger())
+        return listOf(elementsNumber) + list
+    }
 }

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/FeltArray.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/FeltArray.kt
@@ -7,8 +7,5 @@ data class FeltArray(private val list: MutableList<Felt>) : ConvertibleToCalldat
     constructor(collection: Collection<Felt>) : this(collection.toMutableList())
     constructor() : this(emptyList())
 
-    override fun toCalldata(): List<Felt> {
-        val arrayLength = Felt(list.size.toBigInteger())
-        return listOf(arrayLength) + list
-    }
+    override fun toCalldata(): List<Felt> = listOf(size.toFelt) + list
 }

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/FeltArray.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/FeltArray.kt
@@ -8,7 +8,7 @@ data class FeltArray(private val list: MutableList<Felt>) : ConvertibleToCalldat
     constructor() : this(emptyList())
 
     override fun toCalldata(): List<Felt> {
-        val elementsNumber = Felt(list.size.toBigInteger())
-        return listOf(elementsNumber) + list
+        val arraySize = Felt(list.size.toBigInteger())
+        return listOf(arraySize) + list
     }
 }

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/FeltArray.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/FeltArray.kt
@@ -8,7 +8,7 @@ data class FeltArray(private val list: MutableList<Felt>) : ConvertibleToCalldat
     constructor() : this(emptyList())
 
     override fun toCalldata(): List<Felt> {
-        val arraySize = Felt(list.size.toBigInteger())
-        return listOf(arraySize) + list
+        val arrayLength = Felt(list.size.toBigInteger())
+        return listOf(arrayLength) + list
     }
 }

--- a/lib/src/test/kotlin/com/swmansion/starknet/data/types/NumAsHexBaseTests.kt
+++ b/lib/src/test/kotlin/com/swmansion/starknet/data/types/NumAsHexBaseTests.kt
@@ -52,24 +52,24 @@ internal class NumAsHexBaseTests {
     @Test
     fun `numbers to string`() {
         assertEquals(
-                "Felt(0xabcdef01234567890)",
-                Felt.fromHex("0xabcdef01234567890").toString(),
+            "Felt(0xabcdef01234567890)",
+            Felt.fromHex("0xabcdef01234567890").toString(),
         )
         assertEquals(
-                "NumAsHex(0xabcdef01234567890)",
-                NumAsHex.fromHex("0xabcdef01234567890").toString(),
+            "NumAsHex(0xabcdef01234567890)",
+            NumAsHex.fromHex("0xabcdef01234567890").toString(),
         )
         assertEquals(
-                "Uint64(0x1234567890abcdef)",
-                Uint64.fromHex("0x1234567890abcdef").toString(),
+            "Uint64(0x1234567890abcdef)",
+            Uint64.fromHex("0x1234567890abcdef").toString(),
         )
         assertEquals(
-                "Uint128(0xabcdef01234567890)",
-                Uint128.fromHex("0xabcdef01234567890").toString(),
+            "Uint128(0xabcdef01234567890)",
+            Uint128.fromHex("0xabcdef01234567890").toString(),
         )
         assertEquals(
-                "Uint256(58462017464642449753835857636044240746640)",
-                Uint256.fromHex("0xabcdef01234567890abcdef01234567890").toString(),
+            "Uint256(58462017464642449753835857636044240746640)",
+            Uint256.fromHex("0xabcdef01234567890abcdef01234567890").toString(),
         )
     }
 
@@ -132,20 +132,20 @@ internal class NumAsHexBaseTests {
         @Test
         fun `from signed integer`() {
             assertEquals(
-                    Felt.MAX.toFelt,
-                    Felt.fromSigned(-1),
+                Felt.MAX.toFelt,
+                Felt.fromSigned(-1),
             )
             assertEquals(
-                    Felt.ONE,
-                    Felt.fromSigned(-Felt.MAX),
+                Felt.ONE,
+                Felt.fromSigned(-Felt.MAX),
             )
             assertEquals(
-                    (Felt.PRIME - Int.MAX_VALUE.toBigInteger()).toFelt,
-                    Felt.fromSigned(-Int.MAX_VALUE),
+                (Felt.PRIME - Int.MAX_VALUE.toBigInteger()).toFelt,
+                Felt.fromSigned(-Int.MAX_VALUE),
             )
             assertEquals(
-                    (Felt.PRIME - Long.MAX_VALUE.toBigInteger()).toFelt,
-                    Felt.fromSigned(-Long.MAX_VALUE),
+                (Felt.PRIME - Long.MAX_VALUE.toBigInteger()).toFelt,
+                Felt.fromSigned(-Long.MAX_VALUE),
             )
 
             assertEquals(Felt.ZERO, Felt.fromSigned(0))

--- a/lib/src/test/kotlin/com/swmansion/starknet/data/types/NumAsHexBaseTests.kt
+++ b/lib/src/test/kotlin/com/swmansion/starknet/data/types/NumAsHexBaseTests.kt
@@ -52,24 +52,24 @@ internal class NumAsHexBaseTests {
     @Test
     fun `numbers to string`() {
         assertEquals(
-            "Felt(0xabcdef01234567890)",
-            Felt.fromHex("0xabcdef01234567890").toString(),
+                "Felt(0xabcdef01234567890)",
+                Felt.fromHex("0xabcdef01234567890").toString(),
         )
         assertEquals(
-            "NumAsHex(0xabcdef01234567890)",
-            NumAsHex.fromHex("0xabcdef01234567890").toString(),
+                "NumAsHex(0xabcdef01234567890)",
+                NumAsHex.fromHex("0xabcdef01234567890").toString(),
         )
         assertEquals(
-            "Uint64(0x1234567890abcdef)",
-            Uint64.fromHex("0x1234567890abcdef").toString(),
+                "Uint64(0x1234567890abcdef)",
+                Uint64.fromHex("0x1234567890abcdef").toString(),
         )
         assertEquals(
-            "Uint128(0xabcdef01234567890)",
-            Uint128.fromHex("0xabcdef01234567890").toString(),
+                "Uint128(0xabcdef01234567890)",
+                Uint128.fromHex("0xabcdef01234567890").toString(),
         )
         assertEquals(
-            "Uint256(58462017464642449753835857636044240746640)",
-            Uint256.fromHex("0xabcdef01234567890abcdef01234567890").toString(),
+                "Uint256(58462017464642449753835857636044240746640)",
+                Uint256.fromHex("0xabcdef01234567890abcdef01234567890").toString(),
         )
     }
 
@@ -132,20 +132,20 @@ internal class NumAsHexBaseTests {
         @Test
         fun `from signed integer`() {
             assertEquals(
-                Felt.MAX.toFelt,
-                Felt.fromSigned(-1),
+                    Felt.MAX.toFelt,
+                    Felt.fromSigned(-1),
             )
             assertEquals(
-                Felt.ONE,
-                Felt.fromSigned(-Felt.MAX),
+                    Felt.ONE,
+                    Felt.fromSigned(-Felt.MAX),
             )
             assertEquals(
-                (Felt.PRIME - Int.MAX_VALUE.toBigInteger()).toFelt,
-                Felt.fromSigned(-Int.MAX_VALUE),
+                    (Felt.PRIME - Int.MAX_VALUE.toBigInteger()).toFelt,
+                    Felt.fromSigned(-Int.MAX_VALUE),
             )
             assertEquals(
-                (Felt.PRIME - Long.MAX_VALUE.toBigInteger()).toFelt,
-                Felt.fromSigned(-Long.MAX_VALUE),
+                    (Felt.PRIME - Long.MAX_VALUE.toBigInteger()).toFelt,
+                    Felt.fromSigned(-Long.MAX_VALUE),
             )
 
             assertEquals(Felt.ZERO, Felt.fromSigned(0))
@@ -169,11 +169,8 @@ internal class NumAsHexBaseTests {
             val emptyFeltArray = FeltArray()
 
             convertibleToCalldata.add(Felt(15))
-            convertibleToCalldata.add(feltArray1.size.toFelt)
             convertibleToCalldata.add(feltArray1)
-            convertibleToCalldata.add(feltArray2.size.toFelt)
             convertibleToCalldata.add(feltArray2)
-            convertibleToCalldata.add(emptyFeltArray.size.toFelt)
             convertibleToCalldata.add(emptyFeltArray)
 
             val calldata = convertibleToCalldata.toCalldata()


### PR DESCRIPTION
## Describe your changes

- prepend array length to the returned result in `FeltArray.toCalldata`
- update `felt array is convertible to calldata` test

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #433 

## Breaking changes

- [x] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
- `FeltArray.toCalldata` now returns a list with prepended array length instead of just list