### PR TITLE
Re-enable declare devnet tests

### DIFF
--- a/lib/src/test/kotlin/starknet/provider/ProviderTest.kt
+++ b/lib/src/test/kotlin/starknet/provider/ProviderTest.kt
@@ -11,7 +11,6 @@ import com.swmansion.starknet.service.http.HttpService
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.*
 import starknet.utils.DevnetClient
@@ -574,8 +573,6 @@ class ProviderTest {
         assertFalse(receipt.isPending)
     }
 
-    // TODO (#364): Enable this test once declare transaction conforms to the spec on devnet side.
-    @Disabled("Pending declare fix on devnet")
     @Test
     fun `get declare transaction`() {
         val request = provider.getTransaction(declareTransactionHash)


### PR DESCRIPTION
## Describe your changes
As [https://github.com/0xSpaceShard/starknet-devnet-rs/issues/248](https://github.com/0xSpaceShard/starknet-devnet-rs/issues/248) is resolved, we can re-enable declare devnet tests

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #364 

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
