### PR TITLE
Return only hash in `TypeData.encodeValue()`

### DIFF
--- a/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
@@ -391,7 +391,7 @@ data class TypedData private constructor(
 
     private fun prepareMerkletreeRoot(value: JsonArray, context: Context): Felt {
         val merkleTreeType = getMerkleTreeLeavesType(context)
-        val structHashes = value.map { struct -> encodeValue(merkleTreeType, struct).second }
+        val structHashes = value.map { struct -> encodeValue(merkleTreeType, struct) }
 
         return MerkleTree(structHashes, hashMethod).rootHash
     }
@@ -415,7 +415,7 @@ data class TypedData private constructor(
 
         val encodedSubtypes = extractEnumTypes(variantType.type).mapIndexed { index, subtype ->
             val subtypeData = variantData[index]
-            encodeValue(subtype, subtypeData).second
+            encodeValue(subtype, subtypeData)
         }
 
         return hashArray(listOf(variantIndex.toFelt) + encodedSubtypes)
@@ -425,22 +425,22 @@ data class TypedData private constructor(
         typeName: String,
         value: JsonElement,
         context: Context? = null,
-    ): Pair<String, Felt> {
+    ): Felt {
         if (typeName in allTypes) {
-            return typeName to getStructHash(typeName, value.jsonObject)
+            return getStructHash(typeName, value.jsonObject)
         }
 
         if (typeName.isArray()) {
             val hashes = value.jsonArray.map {
-                encodeValue(stripPointer(typeName), it).second
+                encodeValue(stripPointer(typeName), it)
             }
-            return typeName to hashArray(hashes)
+            return hashArray(hashes)
         }
 
         val basicType = BasicType.fromName(typeName, revision)
             ?: throw IllegalArgumentException("Type [$typeName] is not defined in types.")
 
-        return basicType.encodeToType to when (basicType) {
+        return when (basicType) {
             BasicType.Enum -> {
                 requireNotNull(context) { "Context is not provided for '${basicType.name}' type." }
                 prepareEnum(value.jsonObject, context)
@@ -467,7 +467,7 @@ data class TypedData private constructor(
                 value = data.getValue(param.name),
                 Context(typeName, param.name),
             )
-            values.add(encodedValue.second)
+            values.add(encodedValue)
         }
 
         return values
@@ -514,18 +514,17 @@ data class TypedData private constructor(
 
     private sealed class BasicType {
         abstract val name: String
-        open val encodeToType get() = name
 
         sealed interface V0
         sealed interface V1
 
         data object Felt : BasicType(), V0, V1 { override val name = "felt" }
         data object Bool : BasicType(), V0, V1 { override val name = "bool" }
-        data object Selector : BasicType(), V0, V1 { override val name = "selector"; override val encodeToType = Felt.name }
-        data object MerkleTree : BasicType(), V0, V1 { override val name = "merkletree"; override val encodeToType = Felt.name }
+        data object Selector : BasicType(), V0, V1 { override val name = "selector"; }
+        data object MerkleTree : BasicType(), V0, V1 { override val name = "merkletree" }
         data object StringV0 : BasicType(), V0 { override val name = "string" }
         data object StringV1 : BasicType(), V1 { override val name = "string" }
-        data object Enum : BasicType(), V1 { override val name = "enum"; override val encodeToType = Felt.name }
+        data object Enum : BasicType(), V1 { override val name = "enum"; }
         data object I128 : BasicType(), V1 { override val name = "i128" }
         data object U128 : BasicType(), V1 { override val name = "u128" }
         data object ContractAddress : BasicType(), V1 { override val name = "ContractAddress" }

--- a/lib/src/test/kotlin/starknet/data/TypedDataTest.kt
+++ b/lib/src/test/kotlin/starknet/data/TypedDataTest.kt
@@ -295,7 +295,7 @@ internal class TypedDataTest {
 
             assertEquals(rawSelectorValueHash, selectorValueHash)
             assertEquals(
-                "felt" to Felt.fromHex("0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e"),
+                Felt.fromHex("0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e"),
                 selectorValueHash,
             )
         }
@@ -305,7 +305,7 @@ internal class TypedDataTest {
             val values = listOf(true, false, "true", "false", "0x1", "0x0", "1", "0", 1, 0)
             values.forEach {
                 val encodedValue = CasesRev1.TD_BASIC_TYPES.encodeValue("bool", encodeToJsonElement(it))
-                assertTrue(encodedValue.second in listOf(Felt.ONE, Felt.ZERO))
+                assertTrue(encodedValue in listOf(Felt.ONE, Felt.ZERO))
             }
         }
 
@@ -327,7 +327,7 @@ internal class TypedDataTest {
 
             values.forEach {
                 val encodedValue = CasesRev1.TD_BASIC_TYPES.encodeValue("u128", encodeToJsonElement(it))
-                assertEquals(feltFromAny(it), encodedValue.second)
+                assertEquals(feltFromAny(it), encodedValue)
             }
         }
 
@@ -367,7 +367,7 @@ internal class TypedDataTest {
 
             (positiveValues + negativeValues).forEach {
                 val encodedValue = CasesRev1.TD_BASIC_TYPES.encodeValue("i128", encodeToJsonElement(it))
-                assertEquals(feltFromAny(it), encodedValue.second)
+                assertEquals(feltFromAny(it), encodedValue)
             }
         }
 
@@ -442,7 +442,7 @@ internal class TypedDataTest {
                 typeName = "merkletree",
                 value = Json.encodeToJsonElement(tree.leafHashes),
                 context = Context(parent = "Example", key = "root"),
-            ).second
+            )
 
             assertEquals(tree.rootHash, merkleTreeHash)
             assertEquals(Felt.fromHex("0x48924a3b2a7a7b7cc1c9371357e95e322899880a6534bdfe24e96a828b9d780"), merkleTreeHash)
@@ -460,7 +460,7 @@ internal class TypedDataTest {
                 CasesRev0.TD_STRUCT_MERKLETREE.encodeValue(
                     typeName = "Policy",
                     value = Json.encodeToJsonElement(leaf),
-                ).second
+                )
             }
             val tree = MerkleTree(hashedLeaves, HashMethod.PEDERSEN)
 
@@ -468,7 +468,7 @@ internal class TypedDataTest {
                 typeName = "merkletree",
                 value = Json.encodeToJsonElement(leaves),
                 context = Context(parent = "Session", key = "root"),
-            ).second
+            )
 
             assertEquals(tree.rootHash, merkleTreeHash)
             assertEquals(


### PR DESCRIPTION
## Describe your changes
- Change `TypedData.encodeValue(...): Pair<String, Felt>` to `TypedData.encodeValue(...): Felt`
<!-- A brief description of the changes introduced in this PR -->

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #450 

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
