### PR TITLE
Accept key as string in `Provider.getStorageAt()`

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -26,9 +26,9 @@ jobs:
         with:
           submodules: recursive
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@4f73d30c2fc44a9466a3ed890fb8db7a7b554302
+        uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
         with:
-          cmake-version: '3.16.x'
+          cmake-version: '3.18.1'
       - name: Set up Java
         uses: actions/setup-java@v3
         with:

--- a/lib/src/main/kotlin/com/swmansion/starknet/provider/Provider.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/provider/Provider.kt
@@ -1,5 +1,6 @@
 package com.swmansion.starknet.provider
 
+import com.swmansion.starknet.data.selectorFromName
 import com.swmansion.starknet.data.types.*
 import com.swmansion.starknet.provider.exceptions.RequestFailedException
 
@@ -246,6 +247,65 @@ interface Provider {
      * @throws RequestFailedException
      */
     fun getStorageAt(contractAddress: Felt, key: Felt): Request<Felt>
+
+    /**
+     * Get a value of storage var.
+     *
+     * Get a value of a storage variable of contract at the provided address.
+     *
+     * @param contractAddress an address of the contract
+     * @param key an address of the storage variable inside contract
+     * @param blockTag The tag of the requested block.
+     *
+     * @throws RequestFailedException
+     */
+    fun getStorageAt(contractAddress: Felt, key: String, blockTag: BlockTag): Request<Felt> {
+        return getStorageAt(contractAddress, selectorFromName(key), blockTag)
+    }
+
+    /**
+     * Get a value of storage var.
+     *
+     * Get a value of a storage variable of contract at the provided address.
+     *
+     * @param contractAddress an address of the contract
+     * @param key an address of the storage variable inside contract
+     * @param blockHash a hash of the block in respect to what the query will be made
+     *
+     * @throws RequestFailedException
+     */
+    fun getStorageAt(contractAddress: Felt, key: String, blockHash: Felt): Request<Felt> {
+        return getStorageAt(contractAddress, selectorFromName(key), blockHash)
+    }
+
+    /**
+     * Get a value of storage var.
+     *
+     * Get a value of a storage variable of contract at the provided address.
+     *
+     * @param contractAddress an address of the contract
+     * @param key an address of the storage variable inside contract
+     * @param blockNumber a number of the block in respect to what the query will be made
+     *
+     * @throws RequestFailedException
+     */
+    fun getStorageAt(contractAddress: Felt, key: String, blockNumber: Int): Request<Felt> {
+        return getStorageAt(contractAddress, selectorFromName(key), blockNumber)
+    }
+
+    /**
+     * Get a value of storage var.
+     *
+     * Get a value of a storage variable of contract at the provided address and in the latest block.
+     *
+     * @param contractAddress an address of the contract
+     * @param key an address of the storage variable inside contract
+     *
+     * @throws RequestFailedException
+     */
+    fun getStorageAt(contractAddress: Felt, key: String): Request<Felt> {
+        return getStorageAt(contractAddress, selectorFromName(key))
+    }
 
     /**
      * Get transaction receipt

--- a/lib/src/main/kotlin/com/swmansion/starknet/provider/Provider.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/provider/Provider.kt
@@ -1,6 +1,5 @@
 package com.swmansion.starknet.provider
 
-import com.swmansion.starknet.data.selectorFromName
 import com.swmansion.starknet.data.types.*
 import com.swmansion.starknet.provider.exceptions.RequestFailedException
 
@@ -259,9 +258,7 @@ interface Provider {
      *
      * @throws RequestFailedException
      */
-    fun getStorageAt(contractAddress: Felt, key: String, blockTag: BlockTag): Request<Felt> {
-        return getStorageAt(contractAddress, selectorFromName(key), blockTag)
-    }
+    fun getStorageAt(contractAddress: Felt, key: String, blockTag: BlockTag): Request<Felt>
 
     /**
      * Get a value of storage var.
@@ -274,9 +271,7 @@ interface Provider {
      *
      * @throws RequestFailedException
      */
-    fun getStorageAt(contractAddress: Felt, key: String, blockHash: Felt): Request<Felt> {
-        return getStorageAt(contractAddress, selectorFromName(key), blockHash)
-    }
+    fun getStorageAt(contractAddress: Felt, key: String, blockHash: Felt): Request<Felt>
 
     /**
      * Get a value of storage var.
@@ -289,9 +284,7 @@ interface Provider {
      *
      * @throws RequestFailedException
      */
-    fun getStorageAt(contractAddress: Felt, key: String, blockNumber: Int): Request<Felt> {
-        return getStorageAt(contractAddress, selectorFromName(key), blockNumber)
-    }
+    fun getStorageAt(contractAddress: Felt, key: String, blockNumber: Int): Request<Felt>
 
     /**
      * Get a value of storage var.
@@ -303,9 +296,7 @@ interface Provider {
      *
      * @throws RequestFailedException
      */
-    fun getStorageAt(contractAddress: Felt, key: String): Request<Felt> {
-        return getStorageAt(contractAddress, selectorFromName(key))
-    }
+    fun getStorageAt(contractAddress: Felt, key: String): Request<Felt>
 
     /**
      * Get transaction receipt

--- a/lib/src/main/kotlin/com/swmansion/starknet/provider/rpc/JsonRpcProvider.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/provider/rpc/JsonRpcProvider.kt
@@ -1,5 +1,6 @@
 package com.swmansion.starknet.provider.rpc
 
+import com.swmansion.starknet.data.selectorFromName
 import com.swmansion.starknet.data.serializers.*
 import com.swmansion.starknet.data.serializers.BlockWithTransactionsPolymorphicSerializer
 import com.swmansion.starknet.data.serializers.SyncPolymorphicSerializer
@@ -7,6 +8,7 @@ import com.swmansion.starknet.data.serializers.TransactionPolymorphicSerializer
 import com.swmansion.starknet.data.serializers.TransactionReceiptPolymorphicSerializer
 import com.swmansion.starknet.data.types.*
 import com.swmansion.starknet.provider.Provider
+import com.swmansion.starknet.provider.Request
 import com.swmansion.starknet.service.http.*
 import com.swmansion.starknet.service.http.requests.HttpBatchRequest
 import com.swmansion.starknet.service.http.requests.HttpRequest
@@ -195,6 +197,22 @@ class JsonRpcProvider(
 
     override fun getStorageAt(contractAddress: Felt, key: Felt): HttpRequest<Felt> {
         return getStorageAt(contractAddress, key, BlockTag.LATEST)
+    }
+
+    override fun getStorageAt(contractAddress: Felt, key: String, blockTag: BlockTag): Request<Felt> {
+        return getStorageAt(contractAddress, selectorFromName(key), blockTag)
+    }
+
+    override fun getStorageAt(contractAddress: Felt, key: String, blockHash: Felt): Request<Felt> {
+        return getStorageAt(contractAddress, selectorFromName(key), blockHash)
+    }
+
+    override fun getStorageAt(contractAddress: Felt, key: String, blockNumber: Int): Request<Felt> {
+        return getStorageAt(contractAddress, selectorFromName(key), blockNumber)
+    }
+
+    override fun getStorageAt(contractAddress: Felt, key: String): Request<Felt> {
+        return getStorageAt(contractAddress, selectorFromName(key))
     }
 
     override fun getTransaction(transactionHash: Felt): HttpRequest<Transaction> {

--- a/lib/src/test/kotlin/starknet/provider/ProviderTest.kt
+++ b/lib/src/test/kotlin/starknet/provider/ProviderTest.kt
@@ -159,6 +159,18 @@ class ProviderTest {
     }
 
     @Test
+    fun `get storage at with key as string`() {
+        val request = provider.getStorageAt(
+            contractAddress = balanceContractAddress,
+            key = "balance",
+            blockTag = BlockTag.LATEST,
+        )
+
+        val response = request.send()
+        assertTrue(response >= Felt(10))
+    }
+
+    @Test
     fun `get class definition at class hash`() {
         val request = provider.getClass(balanceClassHash)
         val response = request.send()


### PR DESCRIPTION
## Describe your changes

- Add `Provider.getStorageAt()` accepting `key` param as `String`
- Add `JsonRpcProvider.getStorageAt()` implementations
- Add `get storage at with key as string` test in `ProviderTest`
## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #333 

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
