### PR TITLE
Replaced BigInteger Methods like .add(), .mod(), .minus() to Kotlin O…

### DIFF
--- a/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
@@ -445,8 +445,6 @@ class StandardAccount @JvmOverloads constructor(
     }
 
     private fun estimateVersion(version: Felt): Felt {
-        return BigInteger.valueOf(2).pow(128)
-            .add(version.value)
-            .toFelt
-    }
+           return (BigInteger.valueOf(2).pow(128) + version.value).toFelt()
+       }
 }

--- a/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
@@ -20,41 +20,43 @@ import java.util.concurrent.CompletableFuture
  * @param address the address of the account contract
  * @param signer a signer instance used to sign transactions
  * @param chainId the chain id of the Starknet network
- * @param cairoVersion the version of Cairo language in which account contract is written
+ * @param cairoVersion the version of Cairo language in which account
+ *     contract is written
  */
 class StandardAccount @JvmOverloads constructor(
-    override val address: Felt,
-    private val signer: Signer,
-    private val provider: Provider,
-    override val chainId: StarknetChainId,
-    private val cairoVersion: Felt = Felt.ZERO,
+        override val address: Felt,
+        private val signer: Signer,
+        private val provider: Provider,
+        override val chainId: StarknetChainId,
+        private val cairoVersion: Felt = Felt.ZERO,
 ) : Account {
     /**
-     * @param provider a provider used to interact with Starknet
      * @param address the address of the account contract
      * @param privateKey a private key used to create a signer
+     * @param provider a provider used to interact with Starknet
      * @param chainId the chain id of the Starknet network
-     * @param cairoVersion the version of Cairo language in which account contract is written
+     * @param cairoVersion the version of Cairo language in which account
+     *     contract is written
      */
     @JvmOverloads
     constructor(address: Felt, privateKey: Felt, provider: Provider, chainId: StarknetChainId, cairoVersion: Felt = Felt.ZERO) : this(
-        address = address,
-        signer = StarkCurveSigner(privateKey),
-        provider = provider,
-        chainId = chainId,
-        cairoVersion = cairoVersion,
+            address = address,
+            signer = StarkCurveSigner(privateKey),
+            provider = provider,
+            chainId = chainId,
+            cairoVersion = cairoVersion,
     )
 
     override fun signV1(calls: List<Call>, params: ExecutionParams, forFeeEstimate: Boolean): InvokeTransactionV1Payload {
         val calldata = AccountCalldataTransformer.callsToExecuteCalldata(calls, cairoVersion)
         val signVersion = if (forFeeEstimate) TransactionVersion.V1_QUERY else TransactionVersion.V1
         val tx = TransactionFactory.makeInvokeV1Transaction(
-            senderAddress = address,
-            calldata = calldata,
-            chainId = chainId,
-            nonce = params.nonce,
-            maxFee = params.maxFee,
-            version = signVersion,
+                senderAddress = address,
+                calldata = calldata,
+                chainId = chainId,
+                nonce = params.nonce,
+                maxFee = params.maxFee,
+                version = signVersion,
         )
 
         val signedTransaction = tx.copy(signature = signer.signTransaction(tx))
@@ -66,12 +68,12 @@ class StandardAccount @JvmOverloads constructor(
         val calldata = AccountCalldataTransformer.callsToExecuteCalldata(calls, cairoVersion)
         val signVersion = if (forFeeEstimate) TransactionVersion.V3_QUERY else TransactionVersion.V3
         val tx = TransactionFactory.makeInvokeV3Transaction(
-            senderAddress = address,
-            calldata = calldata,
-            chainId = chainId,
-            nonce = params.nonce,
-            version = signVersion,
-            resourceBounds = params.resourceBounds,
+                senderAddress = address,
+                calldata = calldata,
+                chainId = chainId,
+                nonce = params.nonce,
+                version = signVersion,
+                resourceBounds = params.resourceBounds,
         )
 
         val signedTransaction = tx.copy(signature = signer.signTransaction(tx))
@@ -80,23 +82,23 @@ class StandardAccount @JvmOverloads constructor(
     }
 
     override fun signDeployAccountV1(
-        classHash: Felt,
-        calldata: Calldata,
-        salt: Felt,
-        maxFee: Felt,
-        nonce: Felt,
-        forFeeEstimate: Boolean,
+            classHash: Felt,
+            calldata: Calldata,
+            salt: Felt,
+            maxFee: Felt,
+            nonce: Felt,
+            forFeeEstimate: Boolean,
     ): DeployAccountTransactionV1Payload {
         val signVersion = if (forFeeEstimate) TransactionVersion.V1_QUERY else TransactionVersion.V1
         val tx = TransactionFactory.makeDeployAccountV1Transaction(
-            classHash = classHash,
-            contractAddress = address,
-            salt = salt,
-            calldata = calldata,
-            chainId = chainId,
-            maxFee = maxFee,
-            version = signVersion,
-            nonce = nonce,
+                classHash = classHash,
+                contractAddress = address,
+                salt = salt,
+                calldata = calldata,
+                chainId = chainId,
+                maxFee = maxFee,
+                version = signVersion,
+                nonce = nonce,
         )
         val signedTransaction = tx.copy(signature = signer.signTransaction(tx))
 
@@ -104,22 +106,22 @@ class StandardAccount @JvmOverloads constructor(
     }
 
     override fun signDeployAccountV3(
-        classHash: Felt,
-        calldata: Calldata,
-        salt: Felt,
-        params: DeployAccountParamsV3,
-        forFeeEstimate: Boolean,
+            classHash: Felt,
+            calldata: Calldata,
+            salt: Felt,
+            params: DeployAccountParamsV3,
+            forFeeEstimate: Boolean,
     ): DeployAccountTransactionV3Payload {
         val signVersion = if (forFeeEstimate) TransactionVersion.V3_QUERY else TransactionVersion.V3
         val tx = TransactionFactory.makeDeployAccountV3Transaction(
-            classHash = classHash,
-            senderAddress = address,
-            salt = salt,
-            calldata = calldata,
-            chainId = chainId,
-            version = signVersion,
-            nonce = params.nonce,
-            resourceBounds = params.resourceBounds,
+                classHash = classHash,
+                senderAddress = address,
+                salt = salt,
+                calldata = calldata,
+                chainId = chainId,
+                version = signVersion,
+                nonce = params.nonce,
+                resourceBounds = params.resourceBounds,
         )
         val signedTransaction = tx.copy(signature = signer.signTransaction(tx))
 
@@ -127,20 +129,20 @@ class StandardAccount @JvmOverloads constructor(
     }
 
     override fun signDeclareV2(
-        sierraContractDefinition: Cairo1ContractDefinition,
-        casmContractDefinition: CasmContractDefinition,
-        params: ExecutionParams,
-        forFeeEstimate: Boolean,
+            sierraContractDefinition: Cairo1ContractDefinition,
+            casmContractDefinition: CasmContractDefinition,
+            params: ExecutionParams,
+            forFeeEstimate: Boolean,
     ): DeclareTransactionV2Payload {
         val signVersion = if (forFeeEstimate) TransactionVersion.V2_QUERY else TransactionVersion.V2
         val tx = TransactionFactory.makeDeclareV2Transaction(
-            contractDefinition = sierraContractDefinition,
-            senderAddress = address,
-            chainId = chainId,
-            nonce = params.nonce,
-            maxFee = params.maxFee,
-            version = signVersion,
-            casmContractDefinition = casmContractDefinition,
+                contractDefinition = sierraContractDefinition,
+                senderAddress = address,
+                chainId = chainId,
+                nonce = params.nonce,
+                maxFee = params.maxFee,
+                version = signVersion,
+                casmContractDefinition = casmContractDefinition,
         )
         val signedTransaction = tx.copy(signature = signer.signTransaction(tx))
 
@@ -148,20 +150,20 @@ class StandardAccount @JvmOverloads constructor(
     }
 
     override fun signDeclareV3(
-        sierraContractDefinition: Cairo1ContractDefinition,
-        casmContractDefinition: CasmContractDefinition,
-        params: DeclareParamsV3,
-        forFeeEstimate: Boolean,
+            sierraContractDefinition: Cairo1ContractDefinition,
+            casmContractDefinition: CasmContractDefinition,
+            params: DeclareParamsV3,
+            forFeeEstimate: Boolean,
     ): DeclareTransactionV3Payload {
         val signVersion = if (forFeeEstimate) TransactionVersion.V3_QUERY else TransactionVersion.V3
         val tx = TransactionFactory.makeDeclareV3Transaction(
-            contractDefinition = sierraContractDefinition,
-            senderAddress = address,
-            chainId = chainId,
-            nonce = params.nonce,
-            version = signVersion,
-            resourceBounds = params.resourceBounds,
-            casmContractDefinition = casmContractDefinition,
+                contractDefinition = sierraContractDefinition,
+                senderAddress = address,
+                chainId = chainId,
+                nonce = params.nonce,
+                version = signVersion,
+                resourceBounds = params.resourceBounds,
+                casmContractDefinition = casmContractDefinition,
         )
         val signedTransaction = tx.copy(signature = signer.signTransaction(tx))
 
@@ -200,11 +202,12 @@ class StandardAccount @JvmOverloads constructor(
     }
 
     /**
-     * Check if the error message contains part like `Signature ..., is invalid`
+     * Check if the error message contains part like `Signature ..., is
+     * invalid`
      *
      * Account contract `isValidSignature` signature raises an error instead of
-     * returning `0` on invalid signature. We have to check the call error to verify
-     * if it was caused by invalid signature or some other problem.
+     * returning `0` on invalid signature. We have to check the call error to
+     * verify if it was caused by invalid signature or some other problem.
      */
     private fun handleValidationError(e: RequestFailedException): Boolean {
         val regex = """Signature\s.+,\sis\sinvalid""".toRegex()
@@ -229,8 +232,8 @@ class StandardAccount @JvmOverloads constructor(
     override fun executeV3(calls: List<Call>, l1ResourceBounds: ResourceBounds): Request<InvokeFunctionResponse> {
         return getNonce().compose { nonce ->
             val signParams = InvokeParamsV3(
-                nonce = nonce,
-                l1ResourceBounds = l1ResourceBounds,
+                    nonce = nonce,
+                    l1ResourceBounds = l1ResourceBounds,
             )
             val payload = signV3(calls, signParams, false)
 
@@ -246,14 +249,14 @@ class StandardAccount @JvmOverloads constructor(
     }
 
     override fun executeV3(
-        calls: List<Call>,
-        estimateAmountMultiplier: Double,
-        estimateUnitPriceMultiplier: Double,
+            calls: List<Call>,
+            estimateAmountMultiplier: Double,
+            estimateUnitPriceMultiplier: Double,
     ): Request<InvokeFunctionResponse> {
         return estimateFeeV3(calls).compose { estimateFee ->
             val resourceBounds = estimateFee.values.first().toResourceBounds(
-                amountMultiplier = estimateAmountMultiplier,
-                unitPriceMultiplier = estimateUnitPriceMultiplier,
+                    amountMultiplier = estimateAmountMultiplier,
+                    unitPriceMultiplier = estimateUnitPriceMultiplier,
             )
             executeV3(calls, resourceBounds.l1Gas)
         }
@@ -286,14 +289,14 @@ class StandardAccount @JvmOverloads constructor(
     }
 
     override fun executeV3(
-        call: Call,
-        estimateAmountMultiplier: Double,
-        estimateUnitPriceMultiplier: Double,
+            call: Call,
+            estimateAmountMultiplier: Double,
+            estimateUnitPriceMultiplier: Double,
     ): Request<InvokeFunctionResponse> {
         return executeV3(
-            calls = listOf(call),
-            estimateAmountMultiplier = estimateAmountMultiplier,
-            estimateUnitPriceMultiplier = estimateUnitPriceMultiplier,
+                calls = listOf(call),
+                estimateAmountMultiplier = estimateAmountMultiplier,
+                estimateUnitPriceMultiplier = estimateUnitPriceMultiplier,
         )
     }
 
@@ -338,17 +341,17 @@ class StandardAccount @JvmOverloads constructor(
     }
 
     override fun estimateFeeV1(
-        call: Call,
-        blockTag: BlockTag,
-        skipValidate: Boolean,
+            call: Call,
+            blockTag: BlockTag,
+            skipValidate: Boolean,
     ): Request<EstimateFeeResponseList> {
         return estimateFeeV1(listOf(call), blockTag, skipValidate)
     }
 
     override fun estimateFeeV3(
-        call: Call,
-        blockTag: BlockTag,
-        skipValidate: Boolean,
+            call: Call,
+            blockTag: BlockTag,
+            skipValidate: Boolean,
     ): Request<EstimateFeeResponseList> {
         return estimateFeeV3(listOf(call), blockTag, skipValidate)
     }
@@ -378,9 +381,9 @@ class StandardAccount @JvmOverloads constructor(
     }
 
     override fun estimateFeeV1(
-        calls: List<Call>,
-        blockTag: BlockTag,
-        skipValidate: Boolean,
+            calls: List<Call>,
+            blockTag: BlockTag,
+            skipValidate: Boolean,
     ): Request<EstimateFeeResponseList> {
         return getNonce(blockTag).compose { nonce ->
             val simulationFlags = prepareSimulationFlagsForFeeEstimate(skipValidate)
@@ -390,9 +393,9 @@ class StandardAccount @JvmOverloads constructor(
     }
 
     override fun estimateFeeV3(
-        calls: List<Call>,
-        blockTag: BlockTag,
-        skipValidate: Boolean,
+            calls: List<Call>,
+            blockTag: BlockTag,
+            skipValidate: Boolean,
     ): Request<EstimateFeeResponseList> {
         return getNonce(blockTag).compose { nonce ->
             val payload = buildEstimateFeeV3Payload(calls, nonce)
@@ -406,32 +409,32 @@ class StandardAccount @JvmOverloads constructor(
         val payload = signV1(calls, executionParams, true)
 
         val signedTransaction = TransactionFactory.makeInvokeV1Transaction(
-            senderAddress = payload.senderAddress,
-            calldata = payload.calldata,
-            chainId = chainId,
-            nonce = nonce,
-            maxFee = payload.maxFee,
-            signature = payload.signature,
-            version = payload.version,
+                senderAddress = payload.senderAddress,
+                calldata = payload.calldata,
+                chainId = chainId,
+                nonce = nonce,
+                maxFee = payload.maxFee,
+                signature = payload.signature,
+                version = payload.version,
         )
         return listOf(signedTransaction.toPayload())
     }
 
     private fun buildEstimateFeeV3Payload(calls: List<Call>, nonce: Felt): List<TransactionPayload> {
         val executionParams = InvokeParamsV3(
-            nonce = nonce,
-            l1ResourceBounds = ResourceBounds.ZERO,
+                nonce = nonce,
+                l1ResourceBounds = ResourceBounds.ZERO,
         )
         val payload = signV3(calls, executionParams, true)
 
         val signedTransaction = TransactionFactory.makeInvokeV3Transaction(
-            senderAddress = payload.senderAddress,
-            calldata = payload.calldata,
-            chainId = chainId,
-            nonce = nonce,
-            signature = payload.signature,
-            version = payload.version,
-            resourceBounds = payload.resourceBounds,
+                senderAddress = payload.senderAddress,
+                calldata = payload.calldata,
+                chainId = chainId,
+                nonce = nonce,
+                signature = payload.signature,
+                version = payload.version,
+                resourceBounds = payload.resourceBounds,
         )
         return listOf(signedTransaction.toPayload())
     }
@@ -445,6 +448,6 @@ class StandardAccount @JvmOverloads constructor(
     }
 
     private fun estimateVersion(version: Felt): Felt {
-           return (BigInteger.valueOf(2).pow(128) + version.value).toFelt()
-       }
+        return (BigInteger.valueOf(2).pow(128) + version.value).toFelt()
+    }
 }

--- a/lib/src/main/kotlin/com/swmansion/starknet/crypto/Poseidon.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/crypto/Poseidon.kt
@@ -1,155 +1,1 @@
-package com.swmansion.starknet.crypto
-
-import com.swmansion.starknet.data.types.Felt
-import com.swmansion.starknet.extensions.toFelt
-import java.math.BigInteger
-
-/**
- * Split a BigInteger into a little endian array of 4 Long values, each representing a 64-bit chunk of the original BigInteger.
- *
- * @param bigInt the BigInteger to split
- * @return a LongArray containing the 64-bit chunks of the original BigInteger
- */
-private fun splitBigInteger(bigInt: BigInteger): LongArray {
-    val result = LongArray(4)
-
-    // if the input BigInteger is zero, return an array of zeros
-    if (bigInt == BigInteger.ZERO) {
-        return result
-    }
-    // mask has all bits set to 1 except the least significant one
-        val mask = BigInteger.valueOf(2).pow(64) - BigInteger.ONE
-
-    // loop through the 64-bit chunks of the BigInteger, shift them and store in the LongArray
-    for (i in 0 until 4) {
-        result[i] = bigInt.shiftRight(i * 64).and(mask).toLong()
-    }
-
-    return result
-}
-
-/**
- * Convert a LongArray to an Array of BigIntegers.
- *
- * @param longArray the LongArray to convert
- * @return an Array of BigIntegers corresponding to the input LongArray
- */
-@OptIn(ExperimentalUnsignedTypes::class)
-private fun toBigIntegerArray(longArray: LongArray): Array<BigInteger> {
-    val ulongArray = longArray.map { it.toULong() }.toULongArray()
-    return ulongArray.map { BigInteger(it.toString()) }.toTypedArray()
-}
-
-/**
- * Combine a LongArray of 64-bit chunks into a single BigInteger.
- *
- * @param arr the LongArray containing the 64-bit chunks
- * @return a BigInteger representing the combined value of the input LongArray
- */
-private fun unsplitBigInteger(arr: LongArray): BigInteger {
-    val powersOfTwo = listOf(
-        BigInteger.valueOf(2).pow(0),
-        BigInteger.valueOf(2).pow(64),
-        BigInteger.valueOf(2).pow(128),
-        BigInteger.valueOf(2).pow(192),
-    )
-    val barr = toBigIntegerArray(arr)
-    // w * 2**0 + x * 2**64 + y * 2**128 + z * 2**192
-    return barr.zip(powersOfTwo).fold(BigInteger.ZERO) { acc, (b, p) -> acc + b * p }
-}
-
-/**
- * Starknet poseidon utilities.
- *
- * Class with utility methods related to starknet poseidon hash calculation.
- */
-object Poseidon {
-
-    private val m = 3
-    private val r = 2
-
-    init {
-        NativeLoader.load("poseidon")
-        NativeLoader.load("poseidon_jni")
-    }
-
-    /**
-     * Native hades permutation.
-     */
-    @JvmStatic
-    private external fun hades(
-        values: Array<LongArray>,
-    ): Array<LongArray>
-
-    /**
-     * Compute poseidon hash on single Felt.
-     *
-     * @param x single Felt
-     */
-    @JvmStatic
-    fun poseidonHash(x: Felt): Felt {
-        return unsplitBigInteger(
-            hades(
-                arrayOf(
-                    splitBigInteger(BigInteger(x.decString())),
-                    longArrayOf(0, 0, 0, 0),
-                    longArrayOf(1, 0, 0, 0),
-                ),
-            )[0],
-        ).toFelt
-    }
-
-    /**
-     * Compute poseidon hash on two Felts.
-     *
-     * @param x Felt
-     * @param y Felt
-     */
-    @JvmStatic
-    fun poseidonHash(x: Felt, y: Felt): Felt {
-        return unsplitBigInteger(
-            hades(
-                arrayOf(
-                    splitBigInteger(BigInteger(x.decString())),
-                    splitBigInteger(BigInteger(y.decString())),
-                    longArrayOf(2, 0, 0, 0),
-                ),
-            )[0],
-        ).toFelt
-    }
-
-    /**
-     * Compute poseidon hash on many Felts.
-     *
-     * @param values List of Felts
-     */
-    @JvmStatic
-    fun poseidonHash(values: List<Felt>): Felt {
-        val inputValues = values.toMutableList().apply {
-            add(Felt.ONE)
-            if (size % r == 1) add(Felt.ZERO)
-        }
-
-        var state = Array(m) { longArrayOf(0, 0, 0, 0) }
-
-        for (iter in 0 until inputValues.size step 2) {
-            state = hades(
-                arrayOf(
-                    splitBigInteger(unsplitBigInteger(state[0]) + BigInteger(inputValues[iter].decString())),
-                    splitBigInteger(unsplitBigInteger(state[1]) + BigInteger(inputValues[iter + 1].decString())),
-                    state[2],
-                ),
-            )
-        }
-
-        return unsplitBigInteger(state[0]).toFelt
-    }
-
-    /**
-     * Compute poseidon hash on variable number of arguments.
-     *
-     * @param values any number of Felts
-     */
-    @JvmStatic
-    fun poseidonHash(vararg values: Felt): Felt = poseidonHash(values.asList())
-}
+package com.swmansion.starknet.cryptoimport com.swmansion.starknet.data.types.Feltimport com.swmansion.starknet.extensions.toFeltimport java.math.BigInteger/** * Split a BigInteger into a little endian array of 4 Long values, each * representing a 64-bit chunk of the original BigInteger. * * @param bigInt the BigInteger to split * @return a LongArray containing the 64-bit chunks of the original *     BigInteger */private fun splitBigInteger(bigInt: BigInteger): LongArray {    val result = LongArray(4)    // if the input BigInteger is zero, return an array of zeros    if (bigInt == BigInteger.ZERO) {        return result    }    // mask has all bits set to 1 except the least significant one    val mask = BigInteger.valueOf(2).pow(64) - BigInteger.ONE    // loop through the 64-bit chunks of the BigInteger, shift them and store in the LongArray    for (i in 0 until 4) {        result[i] = bigInt.shiftRight(i * 64).and(mask).toLong()    }    return result}/** * Convert a LongArray to an Array of BigIntegers. * * @param longArray the LongArray to convert * @return an Array of BigIntegers corresponding to the input LongArray */@OptIn(ExperimentalUnsignedTypes::class)private fun toBigIntegerArray(longArray: LongArray): Array<BigInteger> {    val ulongArray = longArray.map { it.toULong() }.toULongArray()    return ulongArray.map { BigInteger(it.toString()) }.toTypedArray()}/** * Combine a LongArray of 64-bit chunks into a single BigInteger. * * @param arr the LongArray containing the 64-bit chunks * @return a BigInteger representing the combined value of the input *     LongArray */private fun unsplitBigInteger(arr: LongArray): BigInteger {    val powersOfTwo = listOf(            BigInteger.valueOf(2).pow(0),            BigInteger.valueOf(2).pow(64),            BigInteger.valueOf(2).pow(128),            BigInteger.valueOf(2).pow(192),    )    val barr = toBigIntegerArray(arr)    // w * 2**0 + x * 2**64 + y * 2**128 + z * 2**192    return barr.zip(powersOfTwo).fold(BigInteger.ZERO) { acc, (b, p) -> acc + b * p }}/** * Starknet poseidon utilities. * * Class with utility methods related to starknet poseidon hash * calculation. */object Poseidon {    private val m = 3    private val r = 2    init {        NativeLoader.load("poseidon")        NativeLoader.load("poseidon_jni")    }    /** Native hades permutation. */    @JvmStatic    private external fun hades(            values: Array<LongArray>,    ): Array<LongArray>    /**     * Compute poseidon hash on single Felt.     *     * @param x single Felt     */    @JvmStatic    fun poseidonHash(x: Felt): Felt {        return unsplitBigInteger(                hades(                        arrayOf(                                splitBigInteger(BigInteger(x.decString())),                                longArrayOf(0, 0, 0, 0),                                longArrayOf(1, 0, 0, 0),                        ),                )[0],        ).toFelt    }    /**     * Compute poseidon hash on two Felts.     *     * @param x Felt     * @param y Felt     */    @JvmStatic    fun poseidonHash(x: Felt, y: Felt): Felt {        return unsplitBigInteger(                hades(                        arrayOf(                                splitBigInteger(BigInteger(x.decString())),                                splitBigInteger(BigInteger(y.decString())),                                longArrayOf(2, 0, 0, 0),                        ),                )[0],        ).toFelt    }    /**     * Compute poseidon hash on many Felts.     *     * @param values List of Felts     */    @JvmStatic    fun poseidonHash(values: List<Felt>): Felt {        val inputValues = values.toMutableList().apply {            add(Felt.ONE)            if (size % r == 1) add(Felt.ZERO)        }        var state = Array(m) { longArrayOf(0, 0, 0, 0) }        for (iter in 0 until inputValues.size step 2) {            state = hades(                    arrayOf(                            splitBigInteger(unsplitBigInteger(state[0]) + BigInteger(inputValues[iter].decString())),                            splitBigInteger(unsplitBigInteger(state[1]) + BigInteger(inputValues[iter + 1].decString())),                            state[2],                    ),            )        }        return unsplitBigInteger(state[0]).toFelt    }    /**     * Compute poseidon hash on variable number of arguments.     *     * @param values any number of Felts     */    @JvmStatic    fun poseidonHash(vararg values: Felt): Felt = poseidonHash(values.asList())}

--- a/lib/src/main/kotlin/com/swmansion/starknet/crypto/Poseidon.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/crypto/Poseidon.kt
@@ -18,7 +18,7 @@ private fun splitBigInteger(bigInt: BigInteger): LongArray {
         return result
     }
     // mask has all bits set to 1 except the least significant one
-    val mask = BigInteger.valueOf(2).pow(64).subtract(BigInteger.ONE)
+        val mask = BigInteger.valueOf(2).pow(64) - BigInteger.ONE
 
     // loop through the 64-bit chunks of the BigInteger, shift them and store in the LongArray
     for (i in 0 until 4) {

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/TransactionHashCalculator.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/TransactionHashCalculator.kt
@@ -8,258 +8,254 @@ import com.swmansion.starknet.data.types.TransactionType
 import com.swmansion.starknet.data.types.TransactionVersion
 import com.swmansion.starknet.extensions.toFelt
 
-/**
- * Toolkit for calculating hashes of transactions.
- */
+/** Toolkit for calculating hashes of transactions. */
 object TransactionHashCalculator {
     private val l1GasPrefix by lazy { Felt.fromShortString("L1_GAS") }
     private val l2GasPrefix by lazy { Felt.fromShortString("L2_GAS") }
 
     @JvmStatic
     fun calculateInvokeTxV1Hash(
-        contractAddress: Felt,
-        calldata: Calldata,
-        chainId: StarknetChainId,
-        version: TransactionVersion,
-        nonce: Felt,
-        maxFee: Felt,
+            contractAddress: Felt,
+            calldata: Calldata,
+            chainId: StarknetChainId,
+            version: TransactionVersion,
+            nonce: Felt,
+            maxFee: Felt,
     ): Felt = transactionHashCommon(
-        txType = TransactionType.INVOKE,
-        version = version,
-        contractAddress = contractAddress,
-        entryPointSelector = Felt.ZERO,
-        calldata = calldata,
-        maxFee = maxFee,
-        chainId = chainId,
-        nonce = nonce,
+            txType = TransactionType.INVOKE,
+            version = version,
+            contractAddress = contractAddress,
+            entryPointSelector = Felt.ZERO,
+            calldata = calldata,
+            maxFee = maxFee,
+            chainId = chainId,
+            nonce = nonce,
     )
 
     @JvmStatic
     fun calculateInvokeTxV3Hash(
-        senderAddress: Felt,
-        calldata: Calldata,
-        chainId: StarknetChainId,
-        version: TransactionVersion,
-        nonce: Felt,
-        tip: Uint64,
-        resourceBounds: ResourceBoundsMapping,
-        paymasterData: PaymasterData,
-        accountDeploymentData: AccountDeploymentData,
-        feeDataAvailabilityMode: DAMode,
-        nonceDataAvailabilityMode: DAMode,
+            senderAddress: Felt,
+            calldata: Calldata,
+            chainId: StarknetChainId,
+            version: TransactionVersion,
+            nonce: Felt,
+            tip: Uint64,
+            resourceBounds: ResourceBoundsMapping,
+            paymasterData: PaymasterData,
+            accountDeploymentData: AccountDeploymentData,
+            feeDataAvailabilityMode: DAMode,
+            nonceDataAvailabilityMode: DAMode,
     ): Felt {
         return Poseidon.poseidonHash(
-            *prepareCommonTransanctionV3Fields(
-                txType = TransactionType.INVOKE,
-                version = version,
-                address = senderAddress,
-                tip = tip,
-                resourceBounds = resourceBounds,
-                paymasterData = paymasterData,
-                chainId = chainId,
-                nonce = nonce,
-                nonceDataAvailabilityMode = nonceDataAvailabilityMode,
-                feeDataAvailabilityMode = feeDataAvailabilityMode,
-            ).toTypedArray(),
-            Poseidon.poseidonHash(accountDeploymentData),
-            Poseidon.poseidonHash(calldata),
+                *prepareCommonTransanctionV3Fields(
+                        txType = TransactionType.INVOKE,
+                        version = version,
+                        address = senderAddress,
+                        tip = tip,
+                        resourceBounds = resourceBounds,
+                        paymasterData = paymasterData,
+                        chainId = chainId,
+                        nonce = nonce,
+                        nonceDataAvailabilityMode = nonceDataAvailabilityMode,
+                        feeDataAvailabilityMode = feeDataAvailabilityMode,
+                ).toTypedArray(),
+                Poseidon.poseidonHash(accountDeploymentData),
+                Poseidon.poseidonHash(calldata),
         )
     }
 
     @JvmStatic
     fun calculateDeployAccountV1TxHash(
-        classHash: Felt,
-        calldata: Calldata,
-        salt: Felt,
-        chainId: StarknetChainId,
-        version: TransactionVersion,
-        maxFee: Felt,
-        nonce: Felt,
+            classHash: Felt,
+            calldata: Calldata,
+            salt: Felt,
+            chainId: StarknetChainId,
+            version: TransactionVersion,
+            maxFee: Felt,
+            nonce: Felt,
     ): Felt {
         val contractAddress = ContractAddressCalculator.calculateAddressFromHash(
-            classHash = classHash,
-            calldata = calldata,
-            salt = salt,
+                classHash = classHash,
+                calldata = calldata,
+                salt = salt,
         )
         return transactionHashCommon(
-            txType = TransactionType.DEPLOY_ACCOUNT,
-            version = version,
-            contractAddress = contractAddress,
-            entryPointSelector = Felt.ZERO,
-            calldata = listOf(classHash, salt, *calldata.toTypedArray()),
-            maxFee = maxFee,
-            chainId = chainId,
-            nonce = nonce,
+                txType = TransactionType.DEPLOY_ACCOUNT,
+                version = version,
+                contractAddress = contractAddress,
+                entryPointSelector = Felt.ZERO,
+                calldata = listOf(classHash, salt, *calldata.toTypedArray()),
+                maxFee = maxFee,
+                chainId = chainId,
+                nonce = nonce,
         )
     }
 
     @JvmStatic
     fun calculateDeployAccountV3TxHash(
-        classHash: Felt,
-        constructorCalldata: Calldata,
-        salt: Felt,
-        paymasterData: PaymasterData,
-        chainId: StarknetChainId,
-        version: TransactionVersion,
-        nonce: Felt,
-        tip: Uint64,
-        resourceBounds: ResourceBoundsMapping,
-        feeDataAvailabilityMode: DAMode,
-        nonceDataAvailabilityMode: DAMode,
+            classHash: Felt,
+            constructorCalldata: Calldata,
+            salt: Felt,
+            paymasterData: PaymasterData,
+            chainId: StarknetChainId,
+            version: TransactionVersion,
+            nonce: Felt,
+            tip: Uint64,
+            resourceBounds: ResourceBoundsMapping,
+            feeDataAvailabilityMode: DAMode,
+            nonceDataAvailabilityMode: DAMode,
     ): Felt {
         val contractAddress = ContractAddressCalculator.calculateAddressFromHash(
-            classHash = classHash,
-            calldata = constructorCalldata,
-            salt = salt,
+                classHash = classHash,
+                calldata = constructorCalldata,
+                salt = salt,
         )
         return Poseidon.poseidonHash(
-            *prepareCommonTransanctionV3Fields(
-                txType = TransactionType.DEPLOY_ACCOUNT,
-                version = version,
-                address = contractAddress,
-                tip = tip,
-                resourceBounds = resourceBounds,
-                paymasterData = paymasterData,
-                chainId = chainId,
-                nonce = nonce,
-                nonceDataAvailabilityMode = nonceDataAvailabilityMode,
-                feeDataAvailabilityMode = feeDataAvailabilityMode,
-            ).toTypedArray(),
-            Poseidon.poseidonHash(constructorCalldata),
-            classHash,
-            salt,
+                *prepareCommonTransanctionV3Fields(
+                        txType = TransactionType.DEPLOY_ACCOUNT,
+                        version = version,
+                        address = contractAddress,
+                        tip = tip,
+                        resourceBounds = resourceBounds,
+                        paymasterData = paymasterData,
+                        chainId = chainId,
+                        nonce = nonce,
+                        nonceDataAvailabilityMode = nonceDataAvailabilityMode,
+                        feeDataAvailabilityMode = feeDataAvailabilityMode,
+                ).toTypedArray(),
+                Poseidon.poseidonHash(constructorCalldata),
+                classHash,
+                salt,
         )
     }
 
     @JvmStatic
     fun calculateDeclareV2TxHash(
-        classHash: Felt,
-        chainId: StarknetChainId,
-        senderAddress: Felt,
-        maxFee: Felt,
-        version: TransactionVersion,
-        nonce: Felt,
-        compiledClassHash: Felt,
+            classHash: Felt,
+            chainId: StarknetChainId,
+            senderAddress: Felt,
+            maxFee: Felt,
+            version: TransactionVersion,
+            nonce: Felt,
+            compiledClassHash: Felt,
     ): Felt {
         val calldataHash = StarknetCurve.pedersenOnElements(listOf(classHash))
         return StarknetCurve.pedersenOnElements(
-            TransactionType.DECLARE.txPrefix,
-            version.value,
-            senderAddress,
-            Felt.ZERO,
-            calldataHash,
-            maxFee,
-            chainId.value,
-            nonce,
-            compiledClassHash,
+                TransactionType.DECLARE.txPrefix,
+                version.value,
+                senderAddress,
+                Felt.ZERO,
+                calldataHash,
+                maxFee,
+                chainId.value,
+                nonce,
+                compiledClassHash,
         )
     }
 
     @JvmStatic
     fun calculateDeclareV3TxHash(
-        classHash: Felt,
-        chainId: StarknetChainId,
-        senderAddress: Felt,
-        version: TransactionVersion,
-        nonce: Felt,
-        compiledClassHash: Felt,
-        tip: Uint64,
-        resourceBounds: ResourceBoundsMapping,
-        paymasterData: PaymasterData,
-        accountDeploymentData: AccountDeploymentData,
-        feeDataAvailabilityMode: DAMode,
-        nonceDataAvailabilityMode: DAMode,
+            classHash: Felt,
+            chainId: StarknetChainId,
+            senderAddress: Felt,
+            version: TransactionVersion,
+            nonce: Felt,
+            compiledClassHash: Felt,
+            tip: Uint64,
+            resourceBounds: ResourceBoundsMapping,
+            paymasterData: PaymasterData,
+            accountDeploymentData: AccountDeploymentData,
+            feeDataAvailabilityMode: DAMode,
+            nonceDataAvailabilityMode: DAMode,
     ): Felt {
         return Poseidon.poseidonHash(
-            *prepareCommonTransanctionV3Fields(
-                txType = TransactionType.DECLARE,
-                version = version,
-                address = senderAddress,
-                tip = tip,
-                resourceBounds = resourceBounds,
-                paymasterData = paymasterData,
-                chainId = chainId,
-                nonce = nonce,
-                nonceDataAvailabilityMode = nonceDataAvailabilityMode,
-                feeDataAvailabilityMode = feeDataAvailabilityMode,
-            ).toTypedArray(),
-            Poseidon.poseidonHash(accountDeploymentData),
-            classHash,
-            compiledClassHash,
+                *prepareCommonTransanctionV3Fields(
+                        txType = TransactionType.DECLARE,
+                        version = version,
+                        address = senderAddress,
+                        tip = tip,
+                        resourceBounds = resourceBounds,
+                        paymasterData = paymasterData,
+                        chainId = chainId,
+                        nonce = nonce,
+                        nonceDataAvailabilityMode = nonceDataAvailabilityMode,
+                        feeDataAvailabilityMode = feeDataAvailabilityMode,
+                ).toTypedArray(),
+                Poseidon.poseidonHash(accountDeploymentData),
+                classHash,
+                compiledClassHash,
         )
     }
 
     private fun transactionHashCommon(
-        txType: TransactionType,
-        version: TransactionVersion,
-        contractAddress: Felt,
-        entryPointSelector: Felt,
-        calldata: Calldata,
-        maxFee: Felt,
-        chainId: StarknetChainId,
-        nonce: Felt,
+            txType: TransactionType,
+            version: TransactionVersion,
+            contractAddress: Felt,
+            entryPointSelector: Felt,
+            calldata: Calldata,
+            maxFee: Felt,
+            chainId: StarknetChainId,
+            nonce: Felt,
     ): Felt {
         return StarknetCurve.pedersenOnElements(
-            txType.txPrefix,
-            version.value,
-            contractAddress,
-            entryPointSelector,
-            StarknetCurve.pedersenOnElements(calldata),
-            maxFee,
-            chainId.value,
-            nonce,
+                txType.txPrefix,
+                version.value,
+                contractAddress,
+                entryPointSelector,
+                StarknetCurve.pedersenOnElements(calldata),
+                maxFee,
+                chainId.value,
+                nonce,
         )
     }
 
     private fun prepareCommonTransanctionV3Fields(
-        txType: TransactionType,
-        version: TransactionVersion,
-        address: Felt,
-        tip: Uint64,
-        resourceBounds: ResourceBoundsMapping,
-        paymasterData: PaymasterData,
-        chainId: StarknetChainId,
-        nonce: Felt,
-        nonceDataAvailabilityMode: DAMode,
-        feeDataAvailabilityMode: DAMode,
+            txType: TransactionType,
+            version: TransactionVersion,
+            address: Felt,
+            tip: Uint64,
+            resourceBounds: ResourceBoundsMapping,
+            paymasterData: PaymasterData,
+            chainId: StarknetChainId,
+            nonce: Felt,
+            nonceDataAvailabilityMode: DAMode,
+            feeDataAvailabilityMode: DAMode,
     ): List<Felt> {
         return listOf(
-            txType.txPrefix,
-            version.value,
-            address,
-            Poseidon.poseidonHash(
-                tip.toFelt,
-                *prepareResourceBoundsForFee(resourceBounds).toList().toTypedArray(),
-            ),
-            Poseidon.poseidonHash(paymasterData),
-            chainId.value.toFelt,
-            nonce,
-            prepareDataAvailabilityModes(
-                feeDataAvailabilityMode,
-                nonceDataAvailabilityMode,
-            ),
+                txType.txPrefix,
+                version.value,
+                address,
+                Poseidon.poseidonHash(
+                        tip.toFelt,
+                        *prepareResourceBoundsForFee(resourceBounds).toList().toTypedArray(),
+                ),
+                Poseidon.poseidonHash(paymasterData),
+                chainId.value.toFelt,
+                nonce,
+                prepareDataAvailabilityModes(
+                        feeDataAvailabilityMode,
+                        nonceDataAvailabilityMode,
+                ),
         )
     }
 
     private fun prepareResourceBoundsForFee(resourceBounds: ResourceBoundsMapping): Pair<Felt, Felt> {
         val l1GasBound = l1GasPrefix.value.shiftLeft(64 + 128)
-            .add(resourceBounds.l1Gas.maxAmount.value.shiftLeft(128))
-            .add(resourceBounds.l1Gas.maxPricePerUnit.value)
-            .toFelt
+                .add(resourceBounds.l1Gas.maxAmount.value.shiftLeft(128))
+                .add(resourceBounds.l1Gas.maxPricePerUnit.value)
+                .toFelt
         val l2GasBound = l2GasPrefix.value.shiftLeft(64 + 128)
-            .add(resourceBounds.l2Gas.maxAmount.value.shiftLeft(128))
-            .add(resourceBounds.l2Gas.maxPricePerUnit.value)
-            .toFelt
+                .add(resourceBounds.l2Gas.maxAmount.value.shiftLeft(128))
+                .add(resourceBounds.l2Gas.maxPricePerUnit.value)
+                .toFelt
 
         return l1GasBound to l2GasBound
     }
 
     internal fun prepareDataAvailabilityModes(
-        feeDataAvailabilityMode: DAMode,
-        nonceDataAvailabilityMode: DAMode,
+            feeDataAvailabilityMode: DAMode,
+            nonceDataAvailabilityMode: DAMode,
     ): Felt {
-        return nonceDataAvailabilityMode.value.toBigInteger().shiftLeft(32)
-                    + feeDataAvailabilityMode.value.toBigInteger()
-                    .toFelt
+        return nonceDataAvailabilityMode.value.toBigInteger().shiftLeft(32) + (feeDataAvailabilityMode.value.toBigInteger()).toFelt
     }
 }

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/TransactionHashCalculator.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/TransactionHashCalculator.kt
@@ -259,7 +259,7 @@ object TransactionHashCalculator {
         nonceDataAvailabilityMode: DAMode,
     ): Felt {
         return nonceDataAvailabilityMode.value.toBigInteger().shiftLeft(32)
-            .add(feeDataAvailabilityMode.value.toBigInteger())
-            .toFelt
+                    + feeDataAvailabilityMode.value.toBigInteger()
+                    .toFelt
     }
 }

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/Felt.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/Felt.kt
@@ -59,7 +59,7 @@ data class Felt(override val value: BigInteger) : NumAsHexBase(value), Convertib
         val PRIME = BigInteger("800000000000011000000000000000000000000000000000000000000000001", 16)
 
         @field:JvmField
-        val MAX = PRIME.minus(BigInteger.ONE)
+       val MAX = PRIME - BigInteger.ONE
 
         @field:JvmField
         val ZERO = Felt(BigInteger.ZERO)
@@ -118,7 +118,7 @@ data class Felt(override val value: BigInteger) : NumAsHexBase(value), Convertib
         fun fromSigned(value: BigInteger): Felt {
             require(value.abs() < PRIME) { "Values outside the range (-Felt.PRIME, Felt.PRIME) are not allowed, [$value] given." }
 
-            return Felt(value.mod(PRIME))
+            return Felt(value % PRIME)
         }
 
         /**

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/Felt.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/Felt.kt
@@ -30,7 +30,8 @@ data class Felt(override val value: BigInteger) : NumAsHexBase(value), Convertib
     override fun decString(): String = value.toString(10)
 
     /**
-     * Encode as padded hexadecimal string, including "0x" prefix. Its length is always 66 (including the 0x prefix).
+     * Encode as padded hexadecimal string, including "0x" prefix. Its length
+     * is always 66 (including the 0x prefix).
      */
     fun hexStringPadded(): String {
         val hexString = value.toString(16)
@@ -39,8 +40,8 @@ data class Felt(override val value: BigInteger) : NumAsHexBase(value), Convertib
     }
 
     /**
-     * Encode as ASCII string, with up to 31 characters.
-     * Example: 0x68656c6c6f -> "hello".
+     * Encode as ASCII string, with up to 31 characters. Example: 0x68656c6c6f
+     * -> "hello".
      */
     fun toShortString(): String {
         var hexString = this.value.toString(16)
@@ -59,7 +60,7 @@ data class Felt(override val value: BigInteger) : NumAsHexBase(value), Convertib
         val PRIME = BigInteger("800000000000011000000000000000000000000000000000000000000000001", 16)
 
         @field:JvmField
-       val MAX = PRIME - BigInteger.ONE
+        val MAX = PRIME - BigInteger.ONE
 
         @field:JvmField
         val ZERO = Felt(BigInteger.ZERO)
@@ -78,8 +79,8 @@ data class Felt(override val value: BigInteger) : NumAsHexBase(value), Convertib
         }
 
         /**
-         * Create Felt from ASCII string. It must be shorter than 32 characters and only contain ASCII encoding.
-         * Example: "hello" -> 0x68656c6c6f.
+         * Create Felt from ASCII string. It must be shorter than 32 characters and
+         * only contain ASCII encoding. Example: "hello" -> 0x68656c6c6f.
          *
          * @param value string transformed to felt.
          */
@@ -110,7 +111,8 @@ data class Felt(override val value: BigInteger) : NumAsHexBase(value), Convertib
         }
 
         /**
-         * Create Felt from signed [BigInteger] value. It must be in range (-[Felt.PRIME], [Felt.PRIME]).
+         * Create Felt from signed [BigInteger] value. It must be in range
+         * (-[Felt.PRIME], [Felt.PRIME]).
          *
          * Calculated as [value] mod [Felt.PRIME].
          */

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/Uint128.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/Uint128.kt
@@ -32,7 +32,7 @@ data class Uint128(override val value: BigInteger) : NumAsHexBase(value), Conver
 
     companion object {
         @field:JvmField
-        val MAX = BigInteger.valueOf(2).pow(128).minus(BigInteger.ONE)
+        val MAX = (BigInteger.valueOf(2).pow(128) - BigInteger.ONE)
 
         @field:JvmField
         val ZERO = Uint128(BigInteger.ZERO)

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/Uint256.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/Uint256.kt
@@ -12,7 +12,7 @@ data class Uint256(override val value: BigInteger) : NumAsHexBase(value), Conver
     constructor(value: Long) : this(BigInteger.valueOf(value))
     constructor(value: Int) : this(BigInteger.valueOf(value.toLong()))
     constructor(value: Felt) : this(value.value)
-    constructor(low: BigInteger, high: BigInteger) : this(low.add(high.shiftLeft(SHIFT)))
+    constructor(low: BigInteger, high: BigInteger) : this(low + (high.shiftLeft(SHIFT)))
     constructor(low: Felt, high: Felt) : this(low.value, high.value)
 
     init {
@@ -28,7 +28,7 @@ data class Uint256(override val value: BigInteger) : NumAsHexBase(value), Conver
      * Get low 128 bits of Uint256
      */
     val low: Felt
-        get() = Felt(value.mod(SHIFT_MOD))
+        get() = Felt(value % SHIFT_MOD)
 
     /**
      * Get high 128 bits of Uint256
@@ -46,7 +46,7 @@ data class Uint256(override val value: BigInteger) : NumAsHexBase(value), Conver
 
     companion object {
         @field:JvmField
-        val MAX = BigInteger.valueOf(2).pow(256).minus(BigInteger.ONE)
+        val MAX = (BigInteger.valueOf(2).pow(256) - BigInteger.ONE)
 
         @field:JvmField
         val ZERO = Uint256(BigInteger.ZERO)

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/Uint64.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/Uint64.kt
@@ -32,7 +32,7 @@ data class Uint64(override val value: BigInteger) : NumAsHexBase(value), Convert
 
     companion object {
         @field:JvmField
-        val MAX = BigInteger.valueOf(2).pow(64).minus(BigInteger.ONE)
+        val MAX = (BigInteger.valueOf(2).pow(64) - BigInteger.ONE)
 
         @field:JvmField
         val ZERO = Uint64(BigInteger.ZERO)

--- a/lib/src/test/kotlin/starknet/data/TypedDataTest.kt
+++ b/lib/src/test/kotlin/starknet/data/TypedDataTest.kt
@@ -365,7 +365,7 @@ internal class TypedDataTest {
         @Test
         fun `encode i128`() {
             val positiveValues = listOf(0, 1, 1000000, "0x0", "0x1", "0x64", (BigInteger.TWO.pow(127) - BigInteger.ONE).toString())
-            val negativeValues = listOf(-1, -1000000, "-1", BigInteger.TWO.pow(127).negate().toString())
+            val negativeValues = listOf(-1, -1000000, "-1", (-BigInteger.TWO.pow(127)).toString())
 
             (positiveValues + negativeValues).forEach {
                 val encodedValue = CasesRev1.TD_BASIC_TYPES.encodeValue("i128", encodeToJsonElement(it))


### PR DESCRIPTION
…perators like +, %, -

## Describe your changes

<!-- A brief description of the changes introduced in this PR -->

 I made modifications to the project by replacing BigInteger methods like .add, .mod, .minus() to Kotlin Operators equivalents like +, -, % etc to make it easy and to simplify calculations

As seen in the Screenshot below

![Screenshot 2024-07-04 at 11 23 58 AM](https://github.com/software-mansion/starknet-jvm/assets/147743243/c3312709-0162-4638-bee2-1c76eeef70ea)
![Screenshot 2024-07-04 at 11 24 30 AM](https://github.com/software-mansion/starknet-jvm/assets/147743243/28bcf3ed-988f-4f90-b010-42261e674644)
![Screenshot 2024-07-04 at 11 24 54 AM](https://github.com/software-mansion/starknet-jvm/assets/147743243/666f5f75-a99c-4a73-b4a0-c485c7404278)
![Screenshot 2024-07-04 at 11 25 48 AM](https://github.com/software-mansion/starknet-jvm/assets/147743243/ee74ecfb-d4e4-43d2-a9c4-7db20e979815)


1 `private fun estimateVersion(version: Felt): Felt {
        return BigInteger.valueOf(2).pow(128)
            .add(version.value)
            .toFelt
    }`
    
    was modified to 
    `private fun estimateVersion(version: Felt): Felt {
       return (BigInteger.valueOf(2).pow(128) + version.value).toFelt()
   }`
   
   2 `val mask = BigInteger.valueOf(2).pow(64).subtract(BigInteger.ONE)` was modified to `val mask = BigInteger.valueOf(2).pow(64) - BigInteger.ONE`
   
   3 `constructor(low: BigInteger, high: BigInteger) : this(low.add(high.shiftLeft(SHIFT)))` was modified to `constructor(low: BigInteger, high: BigInteger) : this(low + (high.shiftLeft(SHIFT)))` 
   
   and so on
