### PR TITLE
Fix `TypedData.toJsonString()`

### DIFF
--- a/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
@@ -610,7 +610,7 @@ data class TypedData private constructor(
      * Create a JSON string from TypedData.
      */
     fun toJsonString(): String =
-        Json.encodeToString(serializer(), this)
+        Json { encodeDefaults = true }.encodeToString(serializer(), this)
 }
 
 internal fun String.isArray() = endsWith("*")

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/TypedData.kt
@@ -186,6 +186,7 @@ data class TypedData private constructor(
             Json.decodeFromJsonElement<Revision>(it)
         } ?: Revision.V0
 
+        @Transient
         internal val separatorName = when (resolvedRevision) {
             Revision.V0 -> "StarkNetDomain"
             Revision.V1 -> "StarknetDomain"


### PR DESCRIPTION
## Describe your changes

Fix `TypedData.toJsonString()` by adding `encodeDefaults` flag set to `true`.

Before: `type` field has been skipped while serializing `MerkleTreeType` and `EnumType`, because their value is default
After: `type` field is properly serialized

<!-- A brief description of the changes introduced in this PR -->

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #498 

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
