### PR TITLE
Add `StandardAccount.create()`

### DIFF
--- a/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
@@ -119,11 +119,7 @@ class StandardAccount @JvmOverloads constructor(
         return signedTransaction.toPayload()
     }
 
-    override fun signV3(
-        calls: List<Call>,
-        params: InvokeParamsV3,
-        forFeeEstimate: Boolean,
-    ): InvokeTransactionV3Payload {
+    override fun signV3(calls: List<Call>, params: InvokeParamsV3, forFeeEstimate: Boolean): InvokeTransactionV3Payload {
         val calldata = AccountCalldataTransformer.callsToExecuteCalldata(calls, cairoVersion.version)
         val tx = InvokeTransactionV3(
             senderAddress = address,

--- a/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
@@ -59,7 +59,7 @@ class StandardAccount @JvmOverloads constructor(
          * @param signer a signer instance used to sign transactions
          * @param provider a provider used to interact with Starknet
          * @param chainId the chain id of the Starknet network
-         * @return a StandardAccount instance with determined Cairo version
+         * @return a StandardAccount instance with detected Cairo version
          */
         @JvmStatic
         fun create(
@@ -68,7 +68,7 @@ class StandardAccount @JvmOverloads constructor(
             provider: Provider,
             chainId: StarknetChainId,
         ): StandardAccount {
-            val cairoVersion = determineCairoVersion(provider, address)
+            val cairoVersion = detectCairoVersion(provider, address)
             return StandardAccount(address, signer, provider, chainId, cairoVersion)
         }
 
@@ -79,7 +79,7 @@ class StandardAccount @JvmOverloads constructor(
          * @param privateKey a private key used to create a signer
          * @param provider a provider used to interact with Starknet
          * @param chainId the chain id of the Starknet network
-         * @return a StandardAccount instance with determined Cairo version
+         * @return a StandardAccount instance with detected Cairo version
          */
         @JvmStatic
         fun create(
@@ -89,11 +89,11 @@ class StandardAccount @JvmOverloads constructor(
             chainId: StarknetChainId,
         ): StandardAccount {
             val signer = StarkCurveSigner(privateKey)
-            val cairoVersion = determineCairoVersion(provider, address)
+            val cairoVersion = detectCairoVersion(provider, address)
             return StandardAccount(address, signer, provider, chainId, cairoVersion)
         }
 
-        private fun determineCairoVersion(provider: Provider, address: Felt): CairoVersion {
+        private fun detectCairoVersion(provider: Provider, address: Felt): CairoVersion {
             val contract = provider.getClassAt(address).send()
             return if (contract is ContractClass) CairoVersion.ONE else CairoVersion.ZERO
         }

--- a/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
@@ -99,11 +99,7 @@ class StandardAccount @JvmOverloads constructor(
         }
     }
 
-    override fun signV1(
-        calls: List<Call>,
-        params: ExecutionParams,
-        forFeeEstimate: Boolean,
-    ): InvokeTransactionV1Payload {
+    override fun signV1(calls: List<Call>, params: ExecutionParams, forFeeEstimate: Boolean): InvokeTransactionV1Payload {
         val calldata = AccountCalldataTransformer.callsToExecuteCalldata(calls, cairoVersion.version)
         val tx = InvokeTransactionV1(
             senderAddress = address,

--- a/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
@@ -39,7 +39,21 @@ class StandardAccount(
         signer = signer,
         provider = provider,
         chainId = chainId,
-        cairoVersion = determineCairoVersion(provider, address),
+        cairoVersion = determineCairoVersion(provider, address)
+    )
+
+    constructor(
+        address: Felt,
+        privateKey: Felt,
+        provider: Provider,
+        chainId: StarknetChainId,
+        cairoVersion: CairoVersion
+    ) : this(
+        address = address,
+        signer = StarkCurveSigner(privateKey),
+        provider = provider,
+        chainId = chainId,
+        cairoVersion = cairoVersion,
     )
 
     constructor(

--- a/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
@@ -66,7 +66,7 @@ class StandardAccount @JvmOverloads constructor(
             address: Felt,
             signer: Signer,
             provider: Provider,
-            chainId: StarknetChainId
+            chainId: StarknetChainId,
         ): StandardAccount {
             val cairoVersion = determineCairoVersion(provider, address)
             return StandardAccount(address, signer, provider, chainId, cairoVersion)
@@ -86,7 +86,7 @@ class StandardAccount @JvmOverloads constructor(
             address: Felt,
             privateKey: Felt,
             provider: Provider,
-            chainId: StarknetChainId
+            chainId: StarknetChainId,
         ): StandardAccount {
             val signer = StarkCurveSigner(privateKey)
             val cairoVersion = determineCairoVersion(provider, address)

--- a/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
@@ -39,7 +39,7 @@ class StandardAccount(
         signer = signer,
         provider = provider,
         chainId = chainId,
-        cairoVersion = determineCairoVersion(provider, address)
+        cairoVersion = determineCairoVersion(provider, address),
     )
 
     constructor(
@@ -47,7 +47,7 @@ class StandardAccount(
         privateKey: Felt,
         provider: Provider,
         chainId: StarknetChainId,
-        cairoVersion: CairoVersion
+        cairoVersion: CairoVersion,
     ) : this(
         address = address,
         signer = StarkCurveSigner(privateKey),

--- a/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
@@ -29,6 +29,12 @@ class StandardAccount(
     override val chainId: StarknetChainId,
     private val cairoVersion: CairoVersion,
 ) : Account {
+    /**
+     * @param address the address of the account contract
+     * @param signer a signer instance used to sign transactions
+     * @param provider a provider used to interact with Starknet
+     * @param chainId the chain id of the Starknet network
+     */
     constructor(
         address: Felt,
         signer: Signer,
@@ -42,6 +48,13 @@ class StandardAccount(
         cairoVersion = determineCairoVersion(provider, address),
     )
 
+    /**
+     * @param address the address of the account contract
+     * @param privateKey a private key used to create a signer
+     * @param provider a provider used to interact with Starknet
+     * @param chainId the chain id of the Starknet network
+     * @param cairoVersion the version of Cairo language in which account contract is written
+     */
     constructor(
         address: Felt,
         privateKey: Felt,
@@ -56,6 +69,12 @@ class StandardAccount(
         cairoVersion = cairoVersion,
     )
 
+    /**
+     * @param address the address of the account contract
+     * @param privateKey a private key used to create a signer
+     * @param provider a provider used to interact with Starknet
+     * @param chainId the chain id of the Starknet network
+     */
     constructor(
         address: Felt,
         privateKey: Felt,

--- a/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
@@ -27,32 +27,32 @@ class StandardAccount(
     private val signer: Signer,
     private val provider: Provider,
     override val chainId: StarknetChainId,
-    private val cairoVersion: CairoVersion
+    private val cairoVersion: CairoVersion,
 ) : Account {
     constructor(
         address: Felt,
         signer: Signer,
         provider: Provider,
-        chainId: StarknetChainId
+        chainId: StarknetChainId,
     ) : this(
         address = address,
         signer = signer,
         provider = provider,
         chainId = chainId,
-        cairoVersion = determineCairoVersion(provider, address)
+        cairoVersion = determineCairoVersion(provider, address),
     )
 
     constructor(
         address: Felt,
         privateKey: Felt,
         provider: Provider,
-        chainId: StarknetChainId
+        chainId: StarknetChainId,
     ) : this(
         address = address,
         signer = StarkCurveSigner(privateKey),
         provider = provider,
         chainId = chainId,
-        cairoVersion = determineCairoVersion(provider, address)
+        cairoVersion = determineCairoVersion(provider, address),
     )
 
     companion object {

--- a/lib/src/test/kotlin/network/account/AccountTest.kt
+++ b/lib/src/test/kotlin/network/account/AccountTest.kt
@@ -45,6 +45,7 @@ class AccountTest {
             signer,
             provider,
             chainId,
+            cairoVersion,
         )
 
         // Note to future developers:
@@ -55,6 +56,7 @@ class AccountTest {
             constNonceSigner,
             provider,
             chainId,
+            cairoVersion,
         )
 
         private val predeclaredAccount = when (network) {
@@ -373,6 +375,7 @@ class AccountTest {
             privateKey,
             provider,
             chainId,
+            cairoVersion,
         )
 
         val payloadForFeeEstimation = account.signDeployAccountV1(
@@ -456,6 +459,7 @@ class AccountTest {
             privateKey,
             provider,
             chainId,
+            cairoVersion,
         )
 
         val deployMaxFee = Uint256(5523000060522)
@@ -531,6 +535,7 @@ class AccountTest {
             privateKey,
             provider,
             chainId,
+            cairoVersion,
         )
         val payloadForFeeEstimate = deployedAccount.signDeployAccountV3(
             classHash = classHash,
@@ -675,7 +680,7 @@ class AccountTest {
         val calldata = listOf(publicKey)
         val deployedAccountAddress = ContractAddressCalculator.calculateAddressFromHash(classHash, calldata, salt)
 
-        val deployedAccount = StandardAccount(deployedAccountAddress, privateKey, provider, chainId)
+        val deployedAccount = StandardAccount(deployedAccountAddress, privateKey, provider, chainId, cairoVersion)
         val deployAccountTx = deployedAccount.signDeployAccountV1(
             classHash = classHash,
             salt = salt,

--- a/lib/src/test/kotlin/network/account/AccountTest.kt
+++ b/lib/src/test/kotlin/network/account/AccountTest.kt
@@ -45,7 +45,6 @@ class AccountTest {
             signer,
             provider,
             chainId,
-            cairoVersion,
         )
 
         // Note to future developers:
@@ -56,7 +55,6 @@ class AccountTest {
             constNonceSigner,
             provider,
             chainId,
-            cairoVersion,
         )
 
         private val predeclaredAccount = when (network) {
@@ -375,7 +373,6 @@ class AccountTest {
             privateKey,
             provider,
             chainId,
-            cairoVersion,
         )
 
         val payloadForFeeEstimation = account.signDeployAccountV1(
@@ -459,7 +456,6 @@ class AccountTest {
             privateKey,
             provider,
             chainId,
-            cairoVersion,
         )
 
         val deployMaxFee = Uint256(5523000060522)
@@ -535,7 +531,6 @@ class AccountTest {
             privateKey,
             provider,
             chainId,
-            cairoVersion,
         )
         val payloadForFeeEstimate = deployedAccount.signDeployAccountV3(
             classHash = classHash,
@@ -680,7 +675,7 @@ class AccountTest {
         val calldata = listOf(publicKey)
         val deployedAccountAddress = ContractAddressCalculator.calculateAddressFromHash(classHash, calldata, salt)
 
-        val deployedAccount = StandardAccount(deployedAccountAddress, privateKey, provider, chainId, cairoVersion)
+        val deployedAccount = StandardAccount(deployedAccountAddress, privateKey, provider, chainId)
         val deployAccountTx = deployedAccount.signDeployAccountV1(
             classHash = classHash,
             salt = salt,

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -65,7 +65,7 @@ class StandardAccountTest {
                     signer = signer,
                     provider = provider,
                     chainId = chainId,
-                    cairoVersion = CairoVersion.ZERO,
+                    cairoVersion = CairoVersion.ONE,
                 )
             } catch (ex: Exception) {
                 devnetClient.close()

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -65,7 +65,6 @@ class StandardAccountTest {
                     signer = signer,
                     provider = provider,
                     chainId = chainId,
-                    cairoVersion = CairoVersion.ZERO,
                 )
             } catch (ex: Exception) {
                 devnetClient.close()
@@ -790,7 +789,6 @@ class StandardAccountTest {
                 signer = signer,
                 provider = provider,
                 chainId = chainId,
-                cairoVersion = CairoVersion.ONE,
             )
             val params = ExecutionParams(Felt.ZERO, Felt.ZERO)
             val signedTx = account.signV1(listOf(call1, call2, call3), params)

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -40,15 +40,12 @@ class StandardAccountTest {
         private val provider = JsonRpcProvider(rpcUrl)
 
         private val accountContractClassHash = DevnetClient.accountContractClassHashCairo1
-        private lateinit var accountAddressCairo0: Felt
         private lateinit var accountAddress: Felt
         private lateinit var balanceContractAddress: Felt
 
-        private lateinit var signerCairo0: Signer
         private lateinit var signer: Signer
 
         private lateinit var chainId: StarknetChainId
-        private lateinit var accountCairo0: Account
         private lateinit var account: Account
 
         @JvmStatic
@@ -57,22 +54,12 @@ class StandardAccountTest {
             try {
                 devnetClient.start()
 
-                val accountDetailsCairo0 = devnetClient.createDeployAccount(classHash = DevnetClient.accountContractClassHashCairo0, accountName = "cairo0_account").details
                 val accountDetails = devnetClient.createDeployAccount().details
                 balanceContractAddress = devnetClient.declareDeployContract("Balance", constructorCalldata = listOf(Felt(451))).contractAddress
-                accountAddressCairo0 = accountDetails.address
                 accountAddress = accountDetails.address
 
-                signerCairo0 = StarkCurveSigner(accountDetailsCairo0.privateKey)
                 signer = StarkCurveSigner(accountDetails.privateKey)
                 chainId = provider.getChainId().send()
-                accountCairo0 = StandardAccount(
-                    address = accountAddressCairo0,
-                    signer = signerCairo0,
-                    provider = provider,
-                    chainId = chainId,
-                    cairoVersion = CairoVersion.ZERO,
-                )
                 account = StandardAccount(
                     address = accountAddress,
                     signer = signer,
@@ -105,8 +92,18 @@ class StandardAccountTest {
             entrypoint = "increase_balance",
             calldata = listOf(Felt(10), Felt(20), Felt(30)),
         )
+        val accountDetailsCairo0 = devnetClient.createDeployAccount(classHash = DevnetClient.accountContractClassHashCairo0, accountName = "cairo0_account").details
+        val accountAddressCairo0 = accountDetailsCairo0.address
+        val signerCairo0 = StarkCurveSigner(accountDetailsCairo0.privateKey)
 
+        val accountCairo0 = StandardAccount.create(
+            address = accountAddressCairo0,
+            signer = signerCairo0,
+            provider = provider,
+            chainId = chainId,
+        )
         val params = ExecutionParams(Felt.ZERO, Felt.ZERO)
+
         val signedTx = accountCairo0.signV1(call, params)
 
         val expectedCalldata = listOf(
@@ -122,8 +119,8 @@ class StandardAccountTest {
         )
         assertEquals(expectedCalldata, signedTx.calldata)
 
-        val signedEmptyTx = account.signV1(listOf(), params)
-        assertEquals(listOf(Felt.ZERO), signedEmptyTx.calldata)
+        val signedEmptyTx = accountCairo0.signV1(listOf(), params)
+        assertEquals(listOf(Felt.ZERO, Felt.ZERO), signedEmptyTx.calldata)
     }
 
     @Test

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -86,6 +86,16 @@ class StandardAccountTest {
         StandardAccount(Felt.ZERO, privateKey, provider, chainId)
     }
 
+    @Test
+    fun `creating account with automatic Cairo version determination`() {
+        StandardAccount.create(
+            address = accountAddress,
+            privateKey = Felt(1234),
+            provider = provider,
+            chainId = chainId,
+        )
+    }
+
     @Nested
     inner class NonceTest {
         @Test

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -39,13 +39,16 @@ class StandardAccountTest {
         private val rpcUrl = devnetClient.rpcUrl
         private val provider = JsonRpcProvider(rpcUrl)
 
-        private val accountContractClassHash = DevnetClient.accountContractClassHash
+        private val accountContractClassHash = DevnetClient.accountContractClassHashCairo1
+        private lateinit var accountAddressCairo0: Felt
         private lateinit var accountAddress: Felt
         private lateinit var balanceContractAddress: Felt
 
+        private lateinit var signerCairo0: Signer
         private lateinit var signer: Signer
 
         private lateinit var chainId: StarknetChainId
+        private lateinit var accountCairo0: Account
         private lateinit var account: Account
 
         @JvmStatic
@@ -54,12 +57,22 @@ class StandardAccountTest {
             try {
                 devnetClient.start()
 
+                val accountDetailsCairo0 = devnetClient.createDeployAccount(classHash = DevnetClient.accountContractClassHashCairo0, accountName = "cairo0_account").details
                 val accountDetails = devnetClient.createDeployAccount().details
                 balanceContractAddress = devnetClient.declareDeployContract("Balance", constructorCalldata = listOf(Felt(451))).contractAddress
+                accountAddressCairo0 = accountDetails.address
                 accountAddress = accountDetails.address
 
+                signerCairo0 = StarkCurveSigner(accountDetailsCairo0.privateKey)
                 signer = StarkCurveSigner(accountDetails.privateKey)
                 chainId = provider.getChainId().send()
+                accountCairo0 = StandardAccount(
+                    address = accountAddressCairo0,
+                    signer = signerCairo0,
+                    provider = provider,
+                    chainId = chainId,
+                    cairoVersion = CairoVersion.ZERO,
+                )
                 account = StandardAccount(
                     address = accountAddress,
                     signer = signer,
@@ -87,13 +100,63 @@ class StandardAccountTest {
     }
 
     @Test
-    fun `creating account with automatic Cairo version determination`() {
-        StandardAccount.create(
+    fun `creating cairo 0 account with automatic version determination`() {
+        val call = Call(
+            contractAddress = balanceContractAddress,
+            entrypoint = "increase_balance",
+            calldata = listOf(Felt(10), Felt(20), Felt(30)),
+        )
+
+        val params = ExecutionParams(Felt.ZERO, Felt.ZERO)
+        val signedTx = accountCairo0.signV1(call, params)
+
+        val expectedCalldata = listOf(
+            Felt(1),
+            balanceContractAddress,
+            selectorFromName("increase_balance"),
+            Felt(0),
+            Felt(3),
+            Felt(3),
+            Felt(10),
+            Felt(20),
+            Felt(30),
+        )
+        assertEquals(expectedCalldata, signedTx.calldata)
+
+        val signedEmptyTx = account.signV1(listOf(), params)
+        assertEquals(listOf(Felt.ZERO), signedEmptyTx.calldata)
+    }
+
+    @Test
+    fun `creating cairo 1 account with automatic version determination`() {
+        val call = Call(
+            contractAddress = balanceContractAddress,
+            entrypoint = "increase_balance",
+            calldata = listOf(Felt(10), Felt(20), Felt(30)),
+        )
+
+        val account = StandardAccount.create(
             address = accountAddress,
-            privateKey = Felt(1234),
+            signer = signer,
             provider = provider,
             chainId = chainId,
         )
+        val params = ExecutionParams(Felt.ZERO, Felt.ZERO)
+        val signedTx = account.signV1(call, params)
+
+        val expectedCalldata = listOf(
+            Felt(1),
+            balanceContractAddress,
+            selectorFromName("increase_balance"),
+            Felt(3),
+            Felt(10),
+            Felt(20),
+            Felt(30),
+        )
+        assertEquals(expectedCalldata, signedTx.calldata)
+
+        val signedEmptyTx = account.signV1(listOf(), params)
+        assertEquals(listOf(Felt.ZERO), signedEmptyTx.calldata)
     }
 
     @Nested

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -65,6 +65,7 @@ class StandardAccountTest {
                     signer = signer,
                     provider = provider,
                     chainId = chainId,
+                    cairoVersion = CairoVersion.ZERO,
                 )
             } catch (ex: Exception) {
                 devnetClient.close()
@@ -789,6 +790,7 @@ class StandardAccountTest {
                 signer = signer,
                 provider = provider,
                 chainId = chainId,
+                cairoVersion = CairoVersion.ONE,
             )
             val params = ExecutionParams(Felt.ZERO, Felt.ZERO)
             val signedTx = account.signV1(listOf(call1, call2, call3), params)

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -790,7 +790,7 @@ class StandardAccountTest {
                 signer = signer,
                 provider = provider,
                 chainId = chainId,
-                cairoVersion = CairoVersion.ZERO,
+                cairoVersion = CairoVersion.ONE,
             )
             val params = ExecutionParams(Felt.ZERO, Felt.ZERO)
             val signedTx = account.signV1(listOf(call1, call2, call3), params)

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -124,7 +124,7 @@ class StandardAccountTest {
     }
 
     @Test
-    fun `creating cairo 1 account with automatic version determination`() {
+    fun `cairo 1 account with automatic version detection`() {
         val call = Call(
             contractAddress = balanceContractAddress,
             entrypoint = "increase_balance",

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -86,7 +86,7 @@ class StandardAccountTest {
     }
 
     @Test
-    fun `creating cairo 0 account with automatic version determination`() {
+    fun `cairo 0 account with automatic version detection`() {
         val call = Call(
             contractAddress = balanceContractAddress,
             entrypoint = "increase_balance",

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -65,6 +65,7 @@ class StandardAccountTest {
                     signer = signer,
                     provider = provider,
                     chainId = chainId,
+                    cairoVersion = CairoVersion.ZERO,
                 )
             } catch (ex: Exception) {
                 devnetClient.close()
@@ -789,6 +790,7 @@ class StandardAccountTest {
                 signer = signer,
                 provider = provider,
                 chainId = chainId,
+                cairoVersion = CairoVersion.ZERO,
             )
             val params = ExecutionParams(Felt.ZERO, Felt.ZERO)
             val signedTx = account.signV1(listOf(call1, call2, call3), params)

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -78,7 +78,6 @@ class StandardAccountTest {
                     signer = signer,
                     provider = provider,
                     chainId = chainId,
-                    cairoVersion = CairoVersion.ONE,
                 )
             } catch (ex: Exception) {
                 devnetClient.close()
@@ -863,7 +862,6 @@ class StandardAccountTest {
                 signer = signer,
                 provider = provider,
                 chainId = chainId,
-                cairoVersion = CairoVersion.ONE,
             )
             val params = ExecutionParams(Felt.ZERO, Felt.ZERO)
             val signedTx = account.signV1(listOf(call1, call2, call3), params)

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -48,7 +48,6 @@ class StandardAccountTest {
 
         private lateinit var chainId: StarknetChainId
         private lateinit var account: Account
-        private lateinit var legacyAccount: Account
 
         @JvmStatic
         @BeforeAll
@@ -69,13 +68,6 @@ class StandardAccountTest {
                     signer = signer,
                     provider = provider,
                     chainId = chainId,
-                )
-                legacyAccount = StandardAccount(
-                    address = legacyAccountAddress,
-                    signer = signer,
-                    provider = provider,
-                    chainId = chainId,
-                    cairoVersion = CairoVersion.ZERO,
                 )
             } catch (ex: Exception) {
                 devnetClient.close()
@@ -103,10 +95,15 @@ class StandardAccountTest {
             entrypoint = "increase_balance",
             calldata = listOf(Felt(10), Felt(20), Felt(30)),
         )
-
+        val account = StandardAccount.create(
+            address = legacyAccountAddress,
+            signer = signer,
+            provider = provider,
+            chainId = chainId,
+        )
         val params = ExecutionParams(Felt.ZERO, Felt.ZERO)
 
-        val signedTx = legacyAccount.signV1(call, params)
+        val signedTx = account.signV1(call, params)
 
         val expectedCalldata = listOf(
             Felt(1),
@@ -121,7 +118,7 @@ class StandardAccountTest {
         )
         assertEquals(expectedCalldata, signedTx.calldata)
 
-        val signedEmptyTx = legacyAccount.signV1(listOf(), params)
+        val signedEmptyTx = account.signV1(listOf(), params)
         assertEquals(listOf(Felt.ZERO, Felt.ZERO), signedEmptyTx.calldata)
     }
 

--- a/lib/src/test/kotlin/starknet/utils/DevnetClient.kt
+++ b/lib/src/test/kotlin/starknet/utils/DevnetClient.kt
@@ -56,8 +56,8 @@ class DevnetClient(
 
     companion object {
         // Source: https://github.com/0xSpaceShard/starknet-devnet-rs/blob/47ee2a73c227ee356f344ce94e5f61871299be80/crates/starknet-devnet-core/src/constants.rs
-        val accountContractClassHashCairo0 = Felt.fromHex("0x4d07e40e93398ed3c76981e72dd1fd22557a78ce36c0515f679e27f0bb5bc5f")
-        val accountContractClassHashCairo1 = Felt.fromHex("0x61dac032f228abef9c6626f995015233097ae253a7f72d68552db02f2971b8f")
+        val accountContractClassHash = Felt.fromHex("0x4d07e40e93398ed3c76981e72dd1fd22557a78ce36c0515f679e27f0bb5bc5f")
+        val legacyAccountContractClassHash = Felt.fromHex("0x61dac032f228abef9c6626f995015233097ae253a7f72d68552db02f2971b8f")
         val ethErc20ContractClassHash = Felt.fromHex("0x6a22bf63c7bc07effa39a25dfbd21523d211db0100a0afd054d172b81840eaf")
         val ethErc20ContractAddress = Felt.fromHex("0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7")
         val strkErc20ContractAddress = Felt.fromHex("0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d")
@@ -161,7 +161,7 @@ class DevnetClient(
 
     fun createAccount(
         accountName: String,
-        classHash: Felt = accountContractClassHashCairo1,
+        classHash: Felt = accountContractClassHash,
         salt: Felt? = null,
     ): CreateAccountResult {
         val params = mutableListOf(
@@ -188,7 +188,7 @@ class DevnetClient(
     }
 
     fun deployAccount(
-        classHash: Felt = accountContractClassHashCairo1,
+        classHash: Felt = accountContractClassHash,
         maxFee: Felt = Felt(1000000000000000),
         prefund: Boolean = false,
         accountName: String = "__default__",
@@ -222,7 +222,7 @@ class DevnetClient(
     }
 
     fun createDeployAccount(
-        classHash: Felt = accountContractClassHashCairo1,
+        classHash: Felt = accountContractClassHash,
         salt: Felt? = null,
         maxFee: Felt = Felt(1000000000000000),
         accountName: String = "__default__",

--- a/lib/src/test/kotlin/starknet/utils/DevnetClient.kt
+++ b/lib/src/test/kotlin/starknet/utils/DevnetClient.kt
@@ -56,8 +56,8 @@ class DevnetClient(
 
     companion object {
         // Source: https://github.com/0xSpaceShard/starknet-devnet-rs/blob/47ee2a73c227ee356f344ce94e5f61871299be80/crates/starknet-devnet-core/src/constants.rs
-        val accountContractClassHash = Felt.fromHex("0x4d07e40e93398ed3c76981e72dd1fd22557a78ce36c0515f679e27f0bb5bc5f")
-        val legacyAccountContractClassHash = Felt.fromHex("0x61dac032f228abef9c6626f995015233097ae253a7f72d68552db02f2971b8f")
+        val accountContractClassHash = Felt.fromHex("0x61dac032f228abef9c6626f995015233097ae253a7f72d68552db02f2971b8f")
+        val legacyAccountContractClassHash = Felt.fromHex("0x4d07e40e93398ed3c76981e72dd1fd22557a78ce36c0515f679e27f0bb5bc5f")
         val ethErc20ContractClassHash = Felt.fromHex("0x6a22bf63c7bc07effa39a25dfbd21523d211db0100a0afd054d172b81840eaf")
         val ethErc20ContractAddress = Felt.fromHex("0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7")
         val strkErc20ContractAddress = Felt.fromHex("0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d")

--- a/lib/src/test/kotlin/starknet/utils/DevnetClient.kt
+++ b/lib/src/test/kotlin/starknet/utils/DevnetClient.kt
@@ -56,7 +56,8 @@ class DevnetClient(
 
     companion object {
         // Source: https://github.com/0xSpaceShard/starknet-devnet-rs/blob/47ee2a73c227ee356f344ce94e5f61871299be80/crates/starknet-devnet-core/src/constants.rs
-        val accountContractClassHash = Felt.fromHex("0x61dac032f228abef9c6626f995015233097ae253a7f72d68552db02f2971b8f")
+        val accountContractClassHashCairo0 = Felt.fromHex("0x4d07e40e93398ed3c76981e72dd1fd22557a78ce36c0515f679e27f0bb5bc5f")
+        val accountContractClassHashCairo1 = Felt.fromHex("0x61dac032f228abef9c6626f995015233097ae253a7f72d68552db02f2971b8f")
         val ethErc20ContractClassHash = Felt.fromHex("0x6a22bf63c7bc07effa39a25dfbd21523d211db0100a0afd054d172b81840eaf")
         val ethErc20ContractAddress = Felt.fromHex("0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7")
         val strkErc20ContractAddress = Felt.fromHex("0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d")
@@ -160,7 +161,7 @@ class DevnetClient(
 
     fun createAccount(
         accountName: String,
-        classHash: Felt = accountContractClassHash,
+        classHash: Felt = accountContractClassHashCairo1,
         salt: Felt? = null,
     ): CreateAccountResult {
         val params = mutableListOf(
@@ -187,7 +188,7 @@ class DevnetClient(
     }
 
     fun deployAccount(
-        classHash: Felt = accountContractClassHash,
+        classHash: Felt = accountContractClassHashCairo1,
         maxFee: Felt = Felt(1000000000000000),
         prefund: Boolean = false,
         accountName: String = "__default__",
@@ -221,7 +222,7 @@ class DevnetClient(
     }
 
     fun createDeployAccount(
-        classHash: Felt = accountContractClassHash,
+        classHash: Felt = accountContractClassHashCairo1,
         salt: Felt? = null,
         maxFee: Felt = Felt(1000000000000000),
         accountName: String = "__default__",


### PR DESCRIPTION
## Describe your changes
- Restore `StandardAccount` constructor with `cairoVersion` param
- Change default `cairoVersion` to `CairoVersion.ONE`
- Introduce static method `StandardAccount.create()`, which allows to create a `StandardAccount` instance with automatic determination of Cairo version

<!-- A brief description of the changes introduced in this PR -->

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes

## Breaking changes


- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->