### PR TITLE
Add `StandardAccount.generatePrivateKey()`

### DIFF
--- a/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/account/StandardAccount.kt
@@ -11,6 +11,7 @@ import com.swmansion.starknet.provider.exceptions.RequestFailedException
 import com.swmansion.starknet.signer.Signer
 import com.swmansion.starknet.signer.StarkCurveSigner
 import java.math.BigInteger
+import java.security.SecureRandom
 import java.util.concurrent.CompletableFuture
 
 /**
@@ -96,6 +97,21 @@ class StandardAccount @JvmOverloads constructor(
         private fun detectCairoVersion(provider: Provider, address: Felt): CairoVersion {
             val contract = provider.getClassAt(address).send()
             return if (contract is ContractClass) CairoVersion.ONE else CairoVersion.ZERO
+        }
+
+        /**
+         * Generate a random private key.
+         *
+         * @return private key
+         */
+        @JvmStatic
+        fun generatePrivateKey(): Felt {
+            val random = SecureRandom()
+            val randomBytes = ByteArray(32)
+            random.nextBytes(randomBytes)
+            val randomInt = BigInteger(1, randomBytes)
+            val privateKey = randomInt % Felt.PRIME
+            return privateKey.toFelt
         }
     }
 

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -7,6 +7,8 @@ import com.swmansion.starknet.data.ContractAddressCalculator
 import com.swmansion.starknet.data.selectorFromName
 import com.swmansion.starknet.data.types.*
 import com.swmansion.starknet.extensions.toFelt
+import com.swmansion.starknet.extensions.toHex
+import com.swmansion.starknet.extensions.toUint256
 import com.swmansion.starknet.provider.exceptions.RequestFailedException
 import com.swmansion.starknet.provider.rpc.JsonRpcProvider
 import com.swmansion.starknet.service.http.HttpResponse
@@ -86,6 +88,13 @@ class StandardAccountTest {
     fun `creating account with private key`() {
         val privateKey = Felt(1234)
         StandardAccount(Felt.ZERO, privateKey, provider, chainId)
+    }
+
+    @Test
+    fun `generate random private key`() {
+        val randomPrivateKey = StandardAccount.generatePrivateKey()
+        assertTrue(randomPrivateKey.value < Felt.PRIME)
+        assertTrue(randomPrivateKey.hexStringPadded().length == 66)
     }
 
     @Test

--- a/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
+++ b/lib/src/test/kotlin/starknet/account/StandardAccountTest.kt
@@ -7,8 +7,6 @@ import com.swmansion.starknet.data.ContractAddressCalculator
 import com.swmansion.starknet.data.selectorFromName
 import com.swmansion.starknet.data.types.*
 import com.swmansion.starknet.extensions.toFelt
-import com.swmansion.starknet.extensions.toHex
-import com.swmansion.starknet.extensions.toUint256
 import com.swmansion.starknet.provider.exceptions.RequestFailedException
 import com.swmansion.starknet.provider.rpc.JsonRpcProvider
 import com.swmansion.starknet.service.http.HttpResponse

--- a/lib/starknet-jvm.md
+++ b/lib/starknet-jvm.md
@@ -156,6 +156,10 @@ public class Main {
 
         // Create an account interface
         Felt privateKey = Felt.fromHex("0x123");
+        
+        // You can also generate a random private key
+         Felt randomPrivateKey = StarknetCurve.generatePrivateKey();
+        
         Felt publicKey = StarknetCurve.getPublicKey(privateKey);
 
         // Use the class hash of the desired account contract (i.e. the class hash of OpenZeppelin account contract)


### PR DESCRIPTION
## Describe your changes

Allow users to generate random private key.
- Add static method `StandardAccount.generatePrivateKey()` used to generated random private key

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #506 

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
