### PR TITLE
Allow nullable fields `GetEventsPayload`

### DIFF
--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/Event.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/Event.kt
@@ -64,16 +64,16 @@ data class EmittedEvent @JvmOverloads constructor(
 @Serializable
 data class GetEventsPayload @JvmOverloads constructor(
     @SerialName("from_block")
-    val fromBlockId: BlockId,
+    val fromBlockId: BlockId? = null,
 
     @SerialName("to_block")
-    val toBlockId: BlockId,
+    val toBlockId: BlockId? = null,
 
     @SerialName("address")
-    val address: Felt,
+    val address: Felt? = null,
 
     @SerialName("keys")
-    val keys: List<List<Felt>>,
+    val keys: List<List<Felt>>? = null,
 
     @SerialName("chunk_size")
     val chunkSize: Int,


### PR DESCRIPTION
## Describe your changes

Allow nullable fields in `GetEventsPayload` (apart of `chunkSize` which is required, [spec ref](https://github.com/starkware-libs/starknet-specs/blob/6d88b7399f56260ece3821c71f9ce53ec55f830b/api/starknet_api_openrpc.json#L789)).

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #525 

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
