### PR TITLE
Change `continuationToken` default value to `null`

### DIFF
--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/Event.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/Event.kt
@@ -79,7 +79,7 @@ data class GetEventsPayload @JvmOverloads constructor(
     val chunkSize: Int,
 
     @SerialName("continuation_token")
-    val continuationToken: String? = "0",
+    val continuationToken: String? = null,
 )
 
 @OptIn(ExperimentalSerializationApi::class)
@@ -89,5 +89,5 @@ data class GetEventsResult @JvmOverloads constructor(
     val events: List<EmittedEvent>,
 
     @JsonNames("continuation_token")
-    val continuationToken: String? = "0",
+    val continuationToken: String? = null,
 ) : StarknetResponse


### PR DESCRIPTION
## Describe your changes

Change `continuationToken` default value to `null` in accordance with spec.

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes

## Breaking changes

- [x] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
-  `continuationToken` field in `GetEventsPayload` and `GetEventsResult` has default value `null` instead of `"0"`
