### PR TITLE
Update boost lib download url

### DIFF
--- a/crypto/pedersen/CMakeLists.txt
+++ b/crypto/pedersen/CMakeLists.txt
@@ -30,7 +30,7 @@ int main() {
 if (NOT HAVE_UINT128)
   FetchContent_Declare(
     boostorg
-    URL https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.gz
+    URL https://archives.boost.io/release/1.79.0/source/boost_1_79_0.tar.gz
   )
 
   FetchContent_GetProperties(boostorg)


### PR DESCRIPTION
## Describe your changes

Build workflow failed (example [here](https://github.com/software-mansion/starknet-jvm/actions/runs/14214865048/job/39829144456)), because the old url for boost library download was expired. Updated [it](https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.gz) to an [available one](https://archives.boost.io/release/1.79.0/source/boost_1_79_0.tar.gz).

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
