### PR TITLE
Add cmake setup to docs workflow

### DIFF
--- a/.github/workflows/build-and-publish-docs.yml
+++ b/.github/workflows/build-and-publish-docs.yml
@@ -11,13 +11,19 @@ jobs:
   build-and-publish-docs:
     concurrency: ci-${{ github.ref }}
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+#     TODO: Uncomment this check once running workflow manually is note needed anymore
+#    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
+
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
+        with:
+          cmake-version: '3.18.1'
 
       # Build java and kotlin style docs and copy kotlin output to the java folder
       # so that the deployed github page has java docs at `/` and kotlin docs at `/kotlin`


### PR DESCRIPTION
## Describe your changes

Docs workflow failed (check [this CI run](https://github.com/software-mansion/starknet-jvm/actions/runs/14222779700/job/39856062299)) because cmake was missing - this PR adds it.

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
