### PR TITLE
Support RPC 0.8.1

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -114,13 +114,13 @@ jobs:
             echo "Guides are up-to-date"
           fi
 
-#      - name: Run tests and generate coverage report
-#        env:
-#          DEVNET_PATH: ${{ github.workspace }}/starknet-devnet-rs/target/release/starknet-devnet
-#          NETWORK_TEST_MODE: "disabled"
-#        run: ./gradlew :lib:koverXmlReport --info
-#
-#      - name: Upload coverage to Codecov
-#        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
-#        with:
-#          files: lib/build/reports/kover/report.xml
+      - name: Run tests and generate coverage report
+        env:
+          DEVNET_PATH: ${{ github.workspace }}/starknet-devnet-rs/target/release/starknet-devnet
+          NETWORK_TEST_MODE: "disabled"
+        run: ./gradlew :lib:koverXmlReport --info
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
+        with:
+          files: lib/build/reports/kover/report.xml

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -114,13 +114,13 @@ jobs:
             echo "Guides are up-to-date"
           fi
 
-      - name: Run tests and generate coverage report
-        env:
-          DEVNET_PATH: ${{ github.workspace }}/starknet-devnet-rs/target/release/starknet-devnet
-          NETWORK_TEST_MODE: "disabled"
-        run: ./gradlew :lib:koverXmlReport --info
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
-        with:
-          files: lib/build/reports/kover/report.xml
+#      - name: Run tests and generate coverage report
+#        env:
+#          DEVNET_PATH: ${{ github.workspace }}/starknet-devnet-rs/target/release/starknet-devnet
+#          NETWORK_TEST_MODE: "disabled"
+#        run: ./gradlew :lib:koverXmlReport --info
+#
+#      - name: Upload coverage to Codecov
+#        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
+#        with:
+#          files: lib/build/reports/kover/report.xml

--- a/lib/src/main/kotlin/com/swmansion/starknet/data/types/Responses.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/data/types/Responses.kt
@@ -47,25 +47,25 @@ data class DeployAccountResponse(
 @Serializable
 data class EstimateFeeResponse(
     @SerialName("l1_gas_consumed")
-    val l1GasConsumed: Felt,
+    val l1GasConsumed: Uint64,
 
     @SerialName("l1_gas_price")
-    val l1GasPrice: Felt,
+    val l1GasPrice: Uint128,
 
     @SerialName("l2_gas_consumed")
-    val l2GasConsumed: Felt,
+    val l2GasConsumed: Uint64,
 
     @SerialName("l2_gas_price")
-    val l2GasPrice: Felt,
+    val l2GasPrice: Uint128,
 
     @SerialName("l1_data_gas_consumed")
-    val l1DataGasConsumed: Felt,
+    val l1DataGasConsumed: Uint64,
 
     @SerialName("l1_data_gas_price")
-    val l1DataGasPrice: Felt,
+    val l1DataGasPrice: Uint128,
 
     @SerialName("overall_fee")
-    val overallFee: Felt,
+    val overallFee: Uint128,
 
     // TODO: (#344) Deviation from the spec, make this non-nullable once Pathfinder is updated
     @SerialName("unit")

--- a/lib/src/test/kotlin/starknet/crypto/FeeUtilsTest.kt
+++ b/lib/src/test/kotlin/starknet/crypto/FeeUtilsTest.kt
@@ -9,13 +9,13 @@ import org.junit.jupiter.api.assertThrows
 class FeeUtilsTest {
     companion object {
         val estimateFee = EstimateFeeResponse(
-            l1GasConsumed = Felt(1000),
-            l1GasPrice = Felt(100),
-            l1DataGasConsumed = Felt(1000),
-            l1DataGasPrice = Felt(100),
-            l2GasConsumed = Felt(200),
-            l2GasPrice = Felt(50),
-            overallFee = Felt(1000 * 100 + 200 * 50 + 1000 * 100), // 210000
+            l1GasConsumed = Uint64(1000),
+            l1GasPrice = Uint128(100),
+            l1DataGasConsumed = Uint64(1000),
+            l1DataGasPrice = Uint128(100),
+            l2GasConsumed = Uint64(200),
+            l2GasPrice = Uint128(50),
+            overallFee = Uint128(1000 * 100 + 200 * 50 + 1000 * 100), // 210000
             feeUnit = PriceUnit.WEI,
         )
     }

--- a/lib/src/test/kotlin/starknet/provider/response/JsonRpcResponseTest.kt
+++ b/lib/src/test/kotlin/starknet/provider/response/JsonRpcResponseTest.kt
@@ -46,11 +46,11 @@ class JsonRpcResponseTest {
         val request = provider.getEstimateMessageFee(message, BlockTag.PENDING)
         val response = request.send()
 
-        assertEquals(Felt.fromHex("0x1234"), response.l1GasConsumed)
-        assertEquals(Felt.fromHex("0x5678"), response.l1GasPrice)
-        assertEquals(Felt.fromHex("0x1111"), response.l2GasConsumed)
-        assertEquals(Felt.fromHex("0x2222"), response.l2GasPrice)
-        assertEquals(Felt.fromHex("0x9abc"), response.overallFee)
+        assertEquals(Uint64.fromHex("0x1234"), response.l1GasConsumed)
+        assertEquals(Uint128.fromHex("0x5678"), response.l1GasPrice)
+        assertEquals(Uint64.fromHex("0x1111"), response.l2GasConsumed)
+        assertEquals(Uint128.fromHex("0x2222"), response.l2GasPrice)
+        assertEquals(Uint128.fromHex("0x9abc"), response.overallFee)
         assertEquals(PriceUnit.FRI, response.feeUnit)
 
         val provider2 = JsonRpcProvider("", httpServiceMock, ignoreUnknownJsonKeys = false)


### PR DESCRIPTION
## Describe your changes

Support RPC 0.8.1

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes

## Breaking changes

- [x] This issue contains breaking changes

`EstimateFeeResponse`:
- gas amount fields are now of type `Uint64`
- gas price fields are now of type `Uint128`
- `overallFee` fields is now of type `Uint128`

<!-- List all breaking changes introduced by this issue -->
