### PR TITLE
Update pattern when moving *.jar files

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -155,7 +155,7 @@ jobs:
       - name: Bundle universal JAR
         run: ./gradlew lib:jar
       - name: Rename JAR
-        run: mv lib/build/libs/lib-[0-9].[0-9][0-9].[0-9].jar starknet.jar
+        run: mv lib/build/libs/lib-*.jar starknet.jar
       - name: Upload the JAR
         uses: actions/upload-artifact@v4
         with:
@@ -176,7 +176,7 @@ jobs:
       - name: Generate sources JAR
         run: ./gradlew sourcesJar
       - name: Rename JARS
-        run: mv lib/build/libs/lib-[0-9].[0-9][0-9].[0-9]-javadoc.jar javadoc.jar && mv lib/build/libs/lib-[0-9].[0-9][0-9].[0-9]-sources.jar sources.jar
+        run: mv lib/build/libs/lib-*-javadoc.jar javadoc.jar && mv lib/build/libs/lib-*-sources.jar sources.jar
       - name: Upload javadoc JAR
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Describe your changes

The issue arised because we tried to move files matched by strict pattern (`lib-[0-9].[0-9][0-9].[0-9].jar`, similarly for javadoc and source JARS), which resulted in crash when creating rc version.

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
