### PR TITLE
Fix publishing to maven

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -206,14 +206,12 @@ jobs:
           java-version: 11
           distribution: 'corretto'
       - name: Publish package
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: publish closeAndReleaseRepository
+        run: ./gradlew publishToMavenCentral
         env:
-          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_signingKey }}
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_signingPassword }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ORG_GRADLE_PROJECT_signingKey }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_signingPassword }}
       - uses: softprops/action-gh-release@d4e8205d7e959a9107da6396278b2f1f07af0f9b
         with:
           files: |

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -9,6 +9,9 @@
 import android.databinding.tool.ext.L
 import org.apache.commons.codec.language.bm.Lang
 import org.jetbrains.dokka.gradle.DokkaTask
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import com.vanniktech.maven.publish.JavaLibrary
+import com.vanniktech.maven.publish.JavadocJar
 
 version = "0.16.0-rc.0"
 group = "com.swmansion.starknet"
@@ -18,7 +21,7 @@ plugins {
     id("org.jetbrains.kotlin.jvm")
     id("org.jetbrains.dokka")
     id("org.jmailen.kotlinter")
-    id("io.codearte.nexus-staging") version "0.30.0"
+    id("com.vanniktech.maven.publish") version "0.34.0"
     id("org.jetbrains.kotlinx.kover")
 
     kotlin("plugin.serialization")
@@ -193,7 +196,7 @@ tasks.test {
 
     useJUnitPlatform()
 
-    val libsSharedPath = file("$buildDir/libs/shared").absolutePath
+    val libsSharedPath = file("${layout.buildDirectory}/libs/shared").absolutePath
     val pedersenJniPath = file("${rootDir}/crypto/pedersen/build/bindings").absolutePath
     val poseidonJniPath = file("${rootDir}/crypto/poseidon/build/bindings").absolutePath
     val posedionPath = file("${rootDir}/crypto/poseidon/build/poseidon").absolutePath
@@ -218,7 +221,7 @@ tasks.test {
 // Used by CI. Locally you should use jarWithNative task
 tasks.jar {
     from(
-        file("file:${buildDir}/libs/shared").absolutePath
+        file("file:${layout.buildDirectory}/libs/shared").absolutePath
     )
 }
 
@@ -265,105 +268,70 @@ tasks.javadoc {
     exclude("com.swmansion.starknet.extensions")
 }
 
+mavenPublishing {
+    publishToMavenCentral()
+    signAllPublications()
 
-publishing {
-    publications {
-        create<MavenPublication>("starknet") {
-            artifactId = "starknet"
-            artifact("starknet-jar/starknet.jar")
-            artifact("starknet-aar/starknet.aar")
-            artifact("javadoc-jar/javadoc.jar") {
-                classifier="javadoc"
-            }
-            artifact("sources-jar/sources.jar"){
-                classifier="sources"
-            }
-            pom {
-                name.set("starknet")
-                description.set("Starknet SDK for JVM languages")
-                url.set("https://github.com/software-mansion/starknet-jvm")
-                licenses {
-                    license {
-                        name.set("MIT License")
-                        url.set("https://github.com/software-mansion/starknet-jvm/blob/main/LICENSE")
-                    }
-                }
-                developers {
-                    developer {
-                        id.set("jakubptak")
-                        name.set("Jakub Ptak")
-                        email.set("jakub.ptak@swmansion.com")
-                    }
-                    developer {
-                        id.set("arturmichalek")
-                        name.set("Artur Michałek")
-                        email.set("artur.michalek@swmansion.com")
-                    }
-                    developer {
-                        id.set("bartoszrybarski")
-                        name.set("Bartosz Rybarski")
-                        email.set("bartosz.rybarski@swmansion.com")
-                    }
-                    developer {
-                        id.set("wojciechszymczyk")
-                        name.set("Wojciech Szymczyk")
-                        email.set("wojciech.szymczyk@swmansion.com")
-                    }
-                    developer {
-                        id.set("maksimzdobnikau")
-                        name.set("Maksim Zdobnikau")
-                        email.set("maksim.zdobnikau@swmansion.com")
-                    }
-                    developer {
-                        id.set("franciszekjob")
-                        name.set("Franciszek Job")
-                        email.set("franciszek.job@swmansion.com")
-                    }
-                }
-                scm {
-                    connection.set("scm:git:git://github.com/software-mansion/starknet-jvm.git")
-                    developerConnection.set("scm:git:ssh://github.com:software-mansion/starknet-jvm.git")
-                    url.set("https://github.com/software-mansion/starknet-jvm/tree/main")
-                }
-                pom.withXml {
-                    val dependenciesNode = asNode().appendNode("dependencies")
+    coordinates("com.swmansion.starknet", "starknet", project.version.toString())
 
-                    configurations["implementation"].allDependencies.forEach {
-                        if (it.group != null && it.version != null) {
-                            val dependencyNode = dependenciesNode.appendNode("dependency")
-                            dependencyNode.appendNode("groupId", it.group)
-                            dependencyNode.appendNode("artifactId", it.name)
-                            dependencyNode.appendNode("version", it.version)
-                        }
-                    }
+    pom {
+        name.set("starknet")
+        description.set("Starknet SDK for JVM languages")
+        url.set("https://github.com/software-mansion/starknet-jvm")
+        licenses {
+            license {
+                name.set("MIT License")
+                url.set("https://github.com/software-mansion/starknet-jvm/blob/main/LICENSE")
+            }
+        }
+        developers {
+            developer {
+                id.set("jakubptak")
+                name.set("Jakub Ptak")
+                email.set("jakub.ptak@swmansion.com")
+            }
+            developer {
+                id.set("arturmichalek")
+                name.set("Artur Michałek")
+                email.set("artur.michalek@swmansion.com")
+            }
+            developer {
+                id.set("bartoszrybarski")
+                name.set("Bartosz Rybarski")
+                email.set("bartosz.rybarski@swmansion.com")
+            }
+            developer {
+                id.set("wojciechszymczyk")
+                name.set("Wojciech Szymczyk")
+                email.set("wojciech.szymczyk@swmansion.com")
+            }
+            developer {
+                id.set("maksimzdobnikau")
+                name.set("Maksim Zdobnikau")
+                email.set("maksim.zdobnikau@swmansion.com")
+            }
+            developer {
+                id.set("franciszekjob")
+                name.set("Franciszek Job")
+                email.set("franciszek.job@swmansion.com")
+            }
+        }
+        scm {
+            connection.set("scm:git:git://github.com/software-mansion/starknet-jvm.git")
+            developerConnection.set("scm:git:ssh://github.com:software-mansion/starknet-jvm.git")
+            url.set("https://github.com/software-mansion/starknet-jvm/tree/main")
+        }
+        withXml {
+            val dependenciesNode = asNode().appendNode("dependencies")
+
+            configurations["implementation"].allDependencies.forEach {
+                if (it.group != null && it.version != null) {
+                    val dependencyNode = dependenciesNode.appendNode("dependency")
+                    dependencyNode.appendNode("groupId", it.group)
+                    dependencyNode.appendNode("artifactId", it.name)
+                    dependencyNode.appendNode("version", it.version)
                 }
             }
         }
     }
-    repositories {
-        maven {
-            credentials {
-                username = System.getenv("MAVEN_USERNAME")
-                password = System.getenv("MAVEN_PASSWORD")
-            }
-            val releasesRepoUrl = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
-            val snapshotsRepoUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-            url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
-        }
-
-    }
-}
-
-nexusStaging {
-    serverUrl = "https://s01.oss.sonatype.org/service/local/"
-    packageGroup = "com.swmansion"
-    username = System.getenv("MAVEN_USERNAME")
-    password = System.getenv("MAVEN_PASSWORD")
-}
-
-signing {
-    val signingKey: String? by project
-    val signingPassword: String? by project
-    useInMemoryPgpKeys(signingKey, signingPassword)
-    sign(publishing.publications["starknet"])
 }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -338,3 +338,10 @@ mavenPublishing {
     publishToMavenCentral()
     signAllPublications()
 }
+
+nexusStaging {
+    serverUrl = "https://s01.oss.sonatype.org/service/local/"
+    packageGroup = "com.swmansion"
+    username = System.getenv("MAVEN_USERNAME")
+    password = System.getenv("MAVEN_PASSWORD")
+}

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
     id("org.jetbrains.kotlin.jvm")
     id("org.jetbrains.dokka")
     id("org.jmailen.kotlinter")
+    id("io.codearte.nexus-staging") version "0.30.0"
     id("com.vanniktech.maven.publish") version "0.34.0"
     id("org.jetbrains.kotlinx.kover")
 
@@ -269,9 +270,6 @@ tasks.javadoc {
 }
 
 mavenPublishing {
-    publishToMavenCentral()
-    signAllPublications()
-
     coordinates("com.swmansion.starknet", "starknet", project.version.toString())
 
     pom {
@@ -334,4 +332,9 @@ mavenPublishing {
             }
         }
     }
+}
+
+mavenPublishing {
+    publishToMavenCentral()
+    signAllPublications()
 }


### PR DESCRIPTION
## Describe your changes

Since the end of June 2025, OSSRH service is not working anymore, hence the need to adjust publishing plugin.
For more, please read https://central.sonatype.org/pages/ossrh-eol/

I've chosen https://github.com/vanniktech/gradle-maven-publish-plugin because it was recommended on official gradle website https://cookbook.gradle.org/integrations/maven-central/publishing/#plugins-for-publishing-to-maven-central

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
