### PR TITLE
Use `SonatypeHost.S01` for `publishToMavenCentral`

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -12,6 +12,7 @@ import org.jetbrains.dokka.gradle.DokkaTask
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
 import com.vanniktech.maven.publish.JavaLibrary
 import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.SonatypeHost
 
 version = "0.16.0-rc.0"
 group = "com.swmansion.starknet"
@@ -334,6 +335,6 @@ mavenPublishing {
 }
 
 mavenPublishing {
-    publishToMavenCentral()
+    publishToMavenCentral(SonatypeHost.S01)
     signAllPublications()
 }


### PR DESCRIPTION
## Describe your changes

In 0.27.0 of maven publish plugin, [default Sonatype host](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/0139cc82597460126ed81b8b33e4ba7960c55db2/plugin/src/main/kotlin/com/vanniktech/maven/publish/SonatypeHost.kt#L27) used old OSSRH, this PR uses s01.

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
