### PR TITLE
Fix `linux-aarch64` lib loading

### DIFF
--- a/lib/src/main/kotlin/com/swmansion/starknet/crypto/NativeLoader.kt
+++ b/lib/src/main/kotlin/com/swmansion/starknet/crypto/NativeLoader.kt
@@ -62,8 +62,19 @@ internal object NativeLoader {
     private fun getLibPath(system: SystemType, architecture: String, name: String): String {
         return when (system) {
             SystemType.MacOS -> "/darwin/$name.dylib"
-            SystemType.Linux -> "/linux/$architecture/$name.so"
+            SystemType.Linux -> {
+                val archPath = getPathForArch(architecture)
+                "/linux/$archPath/$name.so"
+            }
             else -> throw UnsupportedPlatform(operatingSystem.name, architecture)
+        }
+    }
+
+    private fun getPathForArch(arch: String): String {
+        return when (arch.lowercase(Locale.ENGLISH)) {
+            "x86_64", "amd64" -> "amd64"
+            "aarch64", "arm64" -> "arm64"
+            else -> arch.lowercase(Locale.ENGLISH)
         }
     }
 }


### PR DESCRIPTION
## Stack
- #614 
- #617
- #616

## Changes

<!-- A brief description of the changes introduced in this PR -->

- Normalize arch path so `linux-aarch64` works


## ✅ Confirmed it works
- https://github.com/DelevoXDG/starknet-jvm-native-loader-test/pull/1/changes/70f72e99277f2a585889b4c19acc93f1400ef9d9

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #612 
